### PR TITLE
support sentinel errors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Build
       run: go build -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,10 @@ linters-settings:
       - wrapperFunc
   gocyclo:
     min-complexity: 15
+  nestif:
+    # Minimal complexity of if statements to report.
+    # Default: 5
+    min-complexity: 8
   gomnd:
     settings:
       mnd:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,7 +117,7 @@ linters:
     # typecheck
     - unconvert
     - unparam
-    - unused
+    #    - unused
     #    - varnamelen
     #- wastedassign
     #    - whitespace

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ bench_go:
 bench_arec:
 	$(GO) test -bench='BenchmarkRecursion.*' $(PKG1)
 
+bench_copy:
+	$(GO) test -bench='Benchmark_CopyBuffer' $(PKG1)
+
 bench_rec:
 	$(GO) test -bench='BenchmarkRecursionWithOldErrorIfCheckAnd_Defer' $(PKG1)
 

--- a/README.md
+++ b/README.md
@@ -141,14 +141,6 @@ If no `Tracer` is set no stack tracing is done. This is the default because in
 the most cases proper error messages are enough and panics are handled
 immediately anyhow.
 
-#### Manual Tracing
-
-The `err2` offers two error catchers for manual stack tracing: `CatchTrace` and
-`CatchAll`. The first one lets you handle errors and it will print the stack
-trace to `stderr` for panic and `runtime.Error`. The second is the same but you
-have a separate handler function for panic and `runtime.Error` so you can decide
-by yourself where to print them or what to do with them.
-
 [Read the package documentation for more
 information](https://pkg.go.dev/github.com/lainio/err2).
 
@@ -292,7 +284,7 @@ means that we don't need to open our internal preconditions just for testing.
 ## Code Snippets
 
 Most of the repetitive code blocks are offered as code snippets. They are in
-`./snippets` in VC code format, which is well supported e.g. vim, etc.
+`./snippets` in VC code format, which is well supported e.g. neovim, etc.
 
 The snippets must be installed manually to your preferred IDE/editor. During the
 installation you can modify the according your style or add new ones. We would
@@ -362,36 +354,77 @@ GitHub Discussions. Naturally, any issues are welcome as well!
 
 ## Roadmap
 
-Version history:
-- 0.1, first draft (Summer 2019)
-- 0.2, code generation for type helpers
-- 0.3, `Returnf` added, not use own transport type anymore but just `error`
-- 0.4, Documentation update
-- 0.5, Go modules are in use
-- 0.6.1, `assert` package added, and new type helpers
-- 0.7.0 filter functions for non-errors like `io.EOF`
-- 0.8.0 `try.To()` & `assert.That()`, etc. functions with the help of the generics
-- 0.8.1 **bug-fix**: `runtime.Error` types are treated as `panics` now (Issue #1)
-- 0.8.3 `try.IsXX()` bug fix, lots of new docs, and **automatic stack tracing!**
-- 0.8.4 **Optimized** Stack Tracing, documentation, benchmarks, etc.
-- 0.8.5 Typo in `StackTraceWriter` fixed
-- 0.8.6 Stack Tracing bug fixed, URL helper restored until migration tool
-- 0.8.7 **Auto-migration tool** to convert deprecated API usage for your repos,
-	`err2.Throwf` added
-- 0.8.8 Assertion package integrates with Go's testing system. Type variables
-        removed.
-- 0.8.9 Bug fixes, deprecations, new Tracer API, preparing `err2` for 1.0
-- 0.8.10 New assertion functions and helpers for tests
-- 0.8.11 Remove deprecations, new *global* err values and `try.IsXX` functions,
-         more documentation.
-- 0.8.12 New super **Handle** for most of the use cases to simplify the API,
-         restructuring internal pkgs, **deferred error handlers are 2x faster
-         now**, new documentation and tests, etc.
-- 0.8.13 **Bug-fix:** automatic error strings for methods, and added API to set
-         preferred error string *Formatter* or implement own.
-- 8.8.14 `err2.Handle` supports sentinel errors, code snippets, asserts, etc.
+### Version history
 
-Upcoming releases:
-- 0.9.0 Clean API: only `err2.Handle` for error returning functions.
-- 0.9.1 Clean API: `err2.CatchXXX` type assertions or many functions?
-- 0.9.2 Clean API: preparing to release 1.0.0 and freeze the API
+##### 0.1
+- first draft (Summer 2019)
+##### 0.2
+- code generation for type helpers
+##### 0.3
+- `Returnf` added, not use own transport type anymore but just `error`
+##### 0.4
+- Documentation update
+##### 0.5
+- Go modules are in use
+##### 0.6.1
+- `assert` package added, and new type helpers
+##### 0.7.0
+- filter functions for non-errors like `io.EOF`
+##### 0.8.0
+- `try.To()`, **Start to use Go generics**
+- `assert.That()` and other assert functions with the help of the generics
+##### 0.8.1
+- **bug-fix**: `runtime.Error` types are treated as `panics` now (Issue #1)
+##### 0.8.3
+- `try.IsXX()` bug fix
+- Lots of new docs
+- **Automatic Stack Tracing!**
+##### 0.8.4
+- **Optimized** Stack Tracing
+- Documentation
+- Benchmarks, other tests
+##### 0.8.5
+- Typo in `StackTraceWriter` fixed
+##### 0.8.6
+- Stack Tracing bug fixed
+- URL helper restored until migration tool
+##### 0.8.7
+- **Auto-migration tool** to convert deprecated API usage for your repos
+- `err2.Throwf` added
+##### 0.8.8
+- **Assertion package integrates with Go's testing system**
+- Type variables removed
+##### 0.8.9
+- Bug fixes
+- deprecations
+- new Tracer API
+- preparing `err2` API for 1.0
+##### 0.8.10
+- New assertion functions and helpers for tests
+##### 0.8.11
+- Remove deprecations
+- new *global* err values and `try.IsXX` functions
+- more documentation
+##### 0.8.12
+- New super **Handle** for most of the use cases to simplify the API
+- **deferred error handlers are 2x faster now**
+- restructuring internal pkgs
+- new documentation and tests, etc.
+##### 0.8.13
+- **Bug-fix:** automatic error strings for methods
+- added API to set preferred error string *Formatter* or implement own
+##### 0.8.14
+- `err2.Handle` supports sentinel errors, can now stop panics
+- `err2.Catch` has one generic API and it stops panics as default
+- deprecated `CatchTrace` and CatchAll` which merged with `Catch`
+- Auto-migration offered (similar to `go fix`)
+- **Code snippets** added
+- New assertion functions
+- no direct variables in APIs (race), etc.
+
+### Upcoming releases
+
+##### 0.9.0 Clean API: only `err2.Handle` for error returning functions.
+##### 0.9.1 Clean API: `err2.CatchXXX` type assertions or many functions?
+    - done in version 0.8.14
+##### 0.9.2 Clean API: preparing to release 1.0.0 and freeze the API

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-<p align="center">
-    <a href="https://github.com/lainio/err2" alt="Activity">
-        <img src="https://img.shields.io/github/commit-activity/m/badges/shields" /></a>
-</p>
-
 # err2
 
 The package extends Go's error handling with **fully automatic error

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<p align="center">
+    <a href="https://github.com/badges/shields/pulse" alt="Activity">
+        <img src="https://img.shields.io/github/commit-activity/m/badges/shields" /></a>
+</p>
+
 # err2
 
 The package extends Go's error handling with **fully automatic error

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ func CopyFile(src, dst string) (err error) {
 - [Backwards Compatibility Promise for the API](#backwards-compatibility-promise-for-the-api)
 - [Assertion (design by contract)](#assertion-design-by-contract)
   - [Assertion Package for Unit Testing](#assertion-package-for-unit-testing)
+- [Code Snippets](#code-snippets)
 - [Background](#background)
 - [Learnings by so far](#learnings-by-so-far)
 - [Support](#support)
@@ -288,6 +289,14 @@ during the execution of called functions like above `NewWebOfTrust()` function
 instead of the actual Test function, it's reported as normal test failure. That
 means that we don't need to open our internal preconditions just for testing.
 
+## Code Snippets
+
+Most of the repetitive code blocks are offered as code snippets. They are in
+`./snippets` in VC code format, which is well supported e.g. vim, etc.
+
+The snippets must be installed manually to your preferred IDE/editor. During the
+installation you can modify the according your style or add new ones. We would
+prefer if you could contribute some of the back to the err2 package.
 
 ## Background
 
@@ -380,6 +389,7 @@ Version history:
          now**, new documentation and tests, etc.
 - 0.8.13 **Bug-fix:** automatic error strings for methods, and added API to set
          preferred error string *Formatter* or implement own.
+- 8.8.14 `err2.Handle` supports sentinel errors, code snippets, asserts, etc.
 
 Upcoming releases:
 - 0.9.0 Clean API: only `err2.Handle` for error returning functions.

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ For more information see the examples of both functions.
 ## Backwards Compatibility Promise for the API
 
 The `err2` package's API will be **backwards compatible**. Before the version
-1.0.0 is released the API changes time to time, but we promise to offer
-automatic conversion scripts for your repos to update them for the latest API.
+1.0.0 is released the API changes time to time, but **we promise to offer
+automatic conversion scripts for your repos to update them for the latest API.**
 We also mark functions deprecated before they become obsolete. Usually one
 released version before. We have tested this in our systems with large code base
 and it works wonderfully.

--- a/README.md
+++ b/README.md
@@ -299,17 +299,22 @@ The package does it by using internally `panic/recovery`, which some might think
 isn't perfect. We have run many benchmarks to try to minimise the performance
 penalty this kind of mechanism might bring. We have focused on the _happy path_
 analyses. If the performance of the *error path* is essential, don't use this
-mechanism presented here. But be aware that if your code uses the error path as 
-a part of algorithm itself something is wrong.
+mechanism presented here. But be aware that if your code uses the **error path
+as a part of algorithm itself something is wrong**.
 
 **For happy paths** by using `try.ToX` error check functions **there are no
 performance penalty at all**. However, the mandatory use of the `defer` might
-prevent some code optimisations like function inlining. If you have a
-performance-critical use case, we recommend you to write performance tests to
-measure the effect. As a general guideline for maximum performance we recommend
-to put error handlers as high in the call stack as possible, and use only error
-checking (`try.To()` calls) in the inner loops. And yes, that leads to non-local
-control structures, but it's the most performant solution of all.
+prevent some code optimisations like function inlining. And still, we have cases
+where using the `err2` and `try` package simplify the algorithm so that it's
+faster than the return value if err != nil version. (See the benchmarks for
+`io.Copy` in the repo)
+
+If you have a performance-critical use case, we always recommend you to write
+performance tests to measure the effect. As a general guideline for maximum
+performance we recommend to put error handlers as high in the call stack as
+possible, and use only error checking (`try.To()` calls) in the inner loops. And
+yes, that leads to non-local control structures, but it's the most performant
+solution of all. (The repo has benchmarks for that as well)
 
 The original goal was to make it possible to write similar code that the
 proposed Go2 error handling would allow and do it right now (summer 2019). The
@@ -319,7 +324,9 @@ canceled at its latest form. Nevertheless, we have learned that **using panics**
 for early-stage **error transport isn't bad but the opposite**. It seems to
 help:
 - to draft algorithms much faster,
-- still maintains the readability,
+- huge improvements for the readability,
+- helps to bring a new blood (developers with different programming language
+  background) to projects,
 - and most importantly, **it keeps your code more refactorable** because you
   don't have to repeat yourself.
 
@@ -426,5 +433,5 @@ GitHub Discussions. Naturally, any issues are welcome as well!
 
 ##### 0.9.0 Clean API: only `err2.Handle` for error returning functions.
 ##### 0.9.1 Clean API: `err2.CatchXXX` type assertions or many functions?
-    - done in version 0.8.14
+- done in version 0.8.14
 ##### 0.9.2 Clean API: preparing to release 1.0.0 and freeze the API

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <a href="https://github.com/badges/shields/pulse" alt="Activity">
+    <a href="https://github.com/lainio/err2" alt="Activity">
         <img src="https://img.shields.io/github/commit-activity/m/badges/shields" /></a>
 </p>
 

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -111,7 +111,7 @@ func That(term bool, a ...any) {
 	}
 }
 
-// NotNil asserts that the value IS NOT nil. If it is it panics/errors (default
+// NotNil asserts that the pointer IS NOT nil. If it is it panics/errors (default
 // Asserter) with the given message.
 func NotNil[T any](p *T, a ...any) {
 	if p == nil {
@@ -123,7 +123,7 @@ func NotNil[T any](p *T, a ...any) {
 	}
 }
 
-// Nil asserts that the value IS nil. If it is not it panics/errors (default
+// Nil asserts that the pointer IS nil. If it is not it panics/errors (default
 // Asserter) with the given message.
 func Nil[T any](p *T, a ...any) {
 	if p != nil {

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -216,6 +216,19 @@ func ExampleMKeyExists() {
 	// Output: sample: assert_test.go:211 ExampleMKeyExists.func1 assertion violation: key '2' doesn't exist
 }
 
+func ExampleZero() {
+	sample := func(b int8) (err error) {
+		defer err2.Handle(&err, "sample")
+
+		assert.Zero(b)
+		return err
+	}
+	var b int8 = 1 // we want sample to assert the violation.
+	err := sample(b)
+	fmt.Printf("%v", err)
+	// Output: sample: assert_test.go:223 ExampleZero.func1 assertion violation: value isn't zero
+}
+
 // ifPanicZero in needed that we have argument here! It's like a macro for
 // benchmarking. The others aren't needed below. TODO: refactor unneeded
 // helpers.
@@ -226,6 +239,10 @@ func ifPanicZero(i int) {
 }
 
 func assertZero(i int) {
+	assert.Zero(i)
+}
+
+func assertNotZero(i int) {
 	assert.D.True(i != 0)
 }
 
@@ -283,7 +300,13 @@ func BenchmarkNotEmpty(b *testing.B) {
 
 func BenchmarkAsserter_True(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		assertZero(4)
+		assertNotZero(4)
+	}
+}
+
+func BenchmarkZero(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		assertZero(0)
 	}
 }
 

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -379,7 +379,7 @@ func TestMain(m *testing.M) {
 }
 
 func setUp() {
-	assert.DefaultAsserter = assert.AsserterToError | assert.AsserterCallerInfo
+	assert.SetDefaultAsserter(assert.AsserterToError | assert.AsserterCallerInfo)
 }
 
 func tearDown() {}

--- a/assert/doc.go
+++ b/assert/doc.go
@@ -11,29 +11,37 @@ add following two lines at the beginning of your unit tests:
 	     alice.Node = root1.Invite(alice.Node, root1.Key, alice.PubKey, 1)
 	     assert.Equal(alice.Len(), 1) // assert anything normally
 
+# Merge Runtime And Test Assertions
+
 Especially powerful feature is that even if some assertion violation happens
-during the execution of called functions like inside of the Invite() function
-instead of the actual Test function, it's reported correctly as normal test
-failure!
+during the execution of called functions not the test it self. See the above
+example. If assertion failure happens inside of the Invite() function instead of
+the actual Test function, TestInvite, it's still reported correctly as normal
+test failure when TestInvite is executed. It doesn't matter how deep the
+recursion is, or if parallel test runs are performed. It works just as you
+hoped.
 
 Instead of mocking or other mechanisms we can integrate our preconditions and
 raise up quality of our software.
 
-	"Assertsions are active comments"
+	"Assertions are active comments"
 
 The package offers a convenient way to set preconditions to code which allow us
 detect programming errors and API violations faster. Still allowing
-production-time error handling if needed. When used with the err2 package panics
-can be turned to normal Go's error values by using proper Asserter like P:
+production-time error handling if needed. And everything is automatic. You can
+set proper asserter according to flag or environment variable. This allows
+developer, operator and every-day user share the exact same binary but get the
+error messages and diagnostic they need.
 
-	assert.P.True(s != "", "sub-command cannot be empty")
+	// add formatted caller info for normal errors coming from assertions
+	assert.SetDefaultAsserter(AsserterToError | AsserterFormattedCallerInfo)
 
 Please see the code examples for more information.
 
-Note. assert.That's performance is equal to the if-statement. Most of the
-generics-based versions are as fast, but some of them (Equal, SLen, MLen)
-aren't. If your algorithm is performance-critical please run `make bench` in the
-err2 repo and decide case by case.
+Note. assert.That's performance has been (<go 1.20) equal to the if-statement.
+Most of the generics-based versions are almost as fast. If your algorithm is
+performance-critical please run `make bench` in the err2 repo and decide case by
+case.
 
 Note. Format string functions need to be own instances because of Go's vet and
 test tool integration.

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,0 +1,42 @@
+package err2_test
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/lainio/err2/internal/helper"
+	"github.com/lainio/err2/try"
+)
+
+func Benchmark_CopyBufferStd(b *testing.B) {
+	all, err := os.ReadFile("./err2_test.go")
+	helper.Requiref(b, err == nil, "error: %v", err)
+	helper.Require(b, all != nil)
+
+	buf := make([]byte, 4)
+	
+	dst := bufio.NewWriter(bytes.NewBuffer(make([]byte, 0, len(all))))
+	src := bytes.NewReader(all)
+	for n := 0; n < b.N; n++ {
+		_, _ = io.CopyBuffer(dst, src, buf)
+	}
+}
+
+func Benchmark_CopyBufferOur(b *testing.B) {
+	all, err := os.ReadFile("err2_test.go")
+	helper.Requiref(b, err == nil, "error: %v", err)
+	helper.Require(b, all != nil)
+
+	tmp := make([]byte, 4)
+	
+	dst := bufio.NewWriter(bytes.NewBuffer(make([]byte, 0, len(all))))
+	src := bytes.NewReader(all)
+	for n := 0; n < b.N; n++ {
+		for eof, n := try.IsEOF1(src.Read(tmp)); !eof; eof, n = try.IsEOF1(src.Read(tmp)) {
+			dst.Write(tmp[:n])
+		}
+	}
+}

--- a/copy_test.go
+++ b/copy_test.go
@@ -17,7 +17,6 @@ func Benchmark_CopyBufferStd(b *testing.B) {
 	helper.Require(b, all != nil)
 
 	buf := make([]byte, 4)
-	
 	dst := bufio.NewWriter(bytes.NewBuffer(make([]byte, 0, len(all))))
 	src := bytes.NewReader(all)
 	for n := 0; n < b.N; n++ {
@@ -31,12 +30,11 @@ func Benchmark_CopyBufferOur(b *testing.B) {
 	helper.Require(b, all != nil)
 
 	tmp := make([]byte, 4)
-	
 	dst := bufio.NewWriter(bytes.NewBuffer(make([]byte, 0, len(all))))
 	src := bytes.NewReader(all)
 	for n := 0; n < b.N; n++ {
 		for eof, n := try.IsEOF1(src.Read(tmp)); !eof; eof, n = try.IsEOF1(src.Read(tmp)) {
-			dst.Write(tmp[:n])
+			_, _ = dst.Write(tmp[:n])
 		}
 	}
 }

--- a/copy_test.go
+++ b/copy_test.go
@@ -20,7 +20,7 @@ func Benchmark_CopyBufferStd(b *testing.B) {
 	dst := bufio.NewWriter(bytes.NewBuffer(make([]byte, 0, len(all))))
 	src := bytes.NewReader(all)
 	for n := 0; n < b.N; n++ {
-		_, _ = io.CopyBuffer(dst, src, buf)
+		try.To1(io.CopyBuffer(dst, src, buf))
 	}
 }
 
@@ -34,7 +34,7 @@ func Benchmark_CopyBufferOur(b *testing.B) {
 	src := bytes.NewReader(all)
 	for n := 0; n < b.N; n++ {
 		for eof, n := try.IsEOF1(src.Read(tmp)); !eof; eof, n = try.IsEOF1(src.Read(tmp)) {
-			_, _ = dst.Write(tmp[:n])
+			try.To1(dst.Write(tmp[:n]))
 		}
 	}
 }

--- a/err2.go
+++ b/err2.go
@@ -42,8 +42,8 @@ var (
 // Note. If you are still using sentinel errors you must be careful with the
 // automatic error annotation because it uses wrapping. If you must keep the
 // error value got from error checks: 'try.To(..)', you must disable automatic
-// error annotation, or set the returned error values in the handler function.
-// Disabling can be done by setting second argument nil:
+// error annotation (%w), or set the returned error values in the handler
+// function. Disabling can be done by setting second argument nil:
 //
 //	func SaveData(...) {
 //	     defer err2.Handle(&err, nil) // nil arg disable automatic annotation.

--- a/err2.go
+++ b/err2.go
@@ -79,10 +79,12 @@ func Catch(a ...any) {
 		return
 	}
 
+	var err error
 	handler.PreProcess(&handler.Info{
 		CallerName: "Catch",
 		Any:        r,
 		NilHandler: handler.NilNoop,
+		Err:        &err,
 	}, a...)
 }
 

--- a/err2.go
+++ b/err2.go
@@ -54,6 +54,16 @@ var (
 //	defer err2.Handle(&err, func() {
 //		os.Remove(dst)
 //	})
+//
+// If you need to stop general panics in handler, you can do that by giving a
+// panic handler function:
+//
+//	defer err2.Handle(&err,
+//	   func() {
+//	      os.Remove(dst)
+//	   },
+//	   func(p any) {} // panic handler, it's stops panics, you can re throw
+//	)
 func Handle(err *error, a ...any) {
 	// This and others are similar but we need to call `recover` here because
 	// how how it works with defer.
@@ -74,8 +84,10 @@ func Handle(err *error, a ...any) {
 }
 
 // Catch is a convenient helper to those functions that doesn't return errors.
-// There can be only one deferred Catch function per non error returning
-// function like main(). There is several ways to make deferred calls to Catch.
+// Note, that Catch always catch the panics. If you don't want to stop the (aka
+// recover) you should add panic handler and countinue panicing there. There can
+// be only one deferred Catch function per non error returning function like
+// main(). There is several ways to make deferred calls to Catch.
 //
 //	defer err2.Catch()
 //
@@ -251,8 +263,8 @@ func doTrace(err error) {
 		return
 	}
 	if ErrorTracer() != nil {
-		fmt.Fprint(ErrorTracer(), err.Error())
+		fmt.Fprintln(ErrorTracer(), err.Error())
 	} else if PanicTracer() != nil {
-		fmt.Fprint(PanicTracer(), err.Error())
+		fmt.Fprintln(PanicTracer(), err.Error())
 	}
 }

--- a/err2.go
+++ b/err2.go
@@ -68,8 +68,7 @@ func Handle(err *error, a ...any) {
 // Catch is a convenient helper to those functions that doesn't return errors.
 // There can be only one deferred Catch function per non error returning
 // function like main(). It doesn't catch panics and runtime errors. If that's
-// important use CatchAll or CatchTrace instead. See Handle for more
-// information.
+// important use CatchAll. See Handle for more information.
 func Catch(f func(err error)) {
 	// This and others are similar but we need to call `recover` here because
 	// how it works with defer.
@@ -87,9 +86,8 @@ func Catch(f func(err error)) {
 }
 
 // CatchAll is a helper function to catch and write handlers for all errors and
-// all panics thrown in the current go routine. It and CatchTrace are preferred
-// helpers for go workers on long running servers, because they stop panics as
-// well.
+// all panics thrown in the current go routine. It is preferred helper for go
+// workers on long running servers, because they stop panics as well.
 //
 // Note, if any Tracer is set stack traces are printed automatically. If you
 // want to do it in the handlers by yourself, auto tracers should be nil.
@@ -119,6 +117,8 @@ func CatchAll(errorHandler func(err error), panicHandler func(v any)) {
 // isn't set. If it's set it prints both. The panic trace is printed to stderr.
 // If you need panic trace to be printed to some other io.Writer than os.Stderr,
 // you should use CatchAll or Catch with tracers.
+//
+// Deprecated: Use err2.Catch() and err2.SetPanicTracer() together instead.
 func CatchTrace(errorHandler func(err error)) {
 	// This and others are similar but we need to call `recover` here because
 	// how it works with defer.

--- a/err2.go
+++ b/err2.go
@@ -38,6 +38,16 @@ var (
 //
 //	func SaveData(...) {
 //	     defer err2.Handle(&err) // if err != nil: annotation is "save data:"
+//
+// Note. If you are still using sentinel errors you must be careful with the
+// automatic error annotation because it uses wrapping. If you must keep the
+// error value got from error checks: 'try.To(..)', you must disable automatic
+// error annotation, or set the returned error values in the handler function.
+// Disabling can be done by setting second argument nil:
+//
+//	func SaveData(...) {
+//	     defer err2.Handle(&err, nil) // nil arg disable automatic annotation.
+//
 func Handle(err *error, a ...any) {
 	// This and others are similar but we need to call `recover` here because
 	// how how it works with defer.

--- a/err2.go
+++ b/err2.go
@@ -47,7 +47,6 @@ var (
 //
 //	func SaveData(...) {
 //	     defer err2.Handle(&err, nil) // nil arg disable automatic annotation.
-//
 func Handle(err *error, a ...any) {
 	// This and others are similar but we need to call `recover` here because
 	// how how it works with defer.

--- a/err2.go
+++ b/err2.go
@@ -154,7 +154,7 @@ func CatchAll(errorHandler func(err error), panicHandler func(v any)) {
 // If you need panic trace to be printed to some other io.Writer than os.Stderr,
 // you should use CatchAll or Catch with tracers.
 //
-// Deprecated: Use err2.Catch() and err2.SetPanicTracer() together instead.
+// Deprecated: Use err2.Catch it stops panics, and tracer if needed.
 func CatchTrace(errorHandler func(err error)) {
 	// This and others are similar but we need to call `recover` here because
 	// how it works with defer.

--- a/err2.go
+++ b/err2.go
@@ -60,8 +60,9 @@ func Handle(err *error, a ...any) {
 	// carrying our errors. We must also call all of the handlers in defer
 	// stack.
 	handler.PreProcess(&handler.Info{
-		Any: r,
-		Err: err,
+		CallerName: "Handle",
+		Any:        r,
+		Err:        err,
 	}, a...)
 }
 
@@ -69,7 +70,7 @@ func Handle(err *error, a ...any) {
 // There can be only one deferred Catch function per non error returning
 // function like main(). It doesn't catch panics and runtime errors. If that's
 // important use CatchAll. See Handle for more information.
-func Catch(f func(err error)) {
+func Catch(a ...any) {
 	// This and others are similar but we need to call `recover` here because
 	// how it works with defer.
 	r := recover()
@@ -78,11 +79,11 @@ func Catch(f func(err error)) {
 		return
 	}
 
-	handler.Process(&handler.Info{
-		Any:          r,
-		ErrorHandler: f,
-		NilHandler:   handler.NilNoop,
-	})
+	handler.PreProcess(&handler.Info{
+		CallerName: "Catch",
+		Any:        r,
+		NilHandler: handler.NilNoop,
+	}, a...)
 }
 
 // CatchAll is a helper function to catch and write handlers for all errors and
@@ -91,6 +92,7 @@ func Catch(f func(err error)) {
 //
 // Note, if any Tracer is set stack traces are printed automatically. If you
 // want to do it in the handlers by yourself, auto tracers should be nil.
+// Deprecated: use Catch for everything
 func CatchAll(errorHandler func(err error), panicHandler func(v any)) {
 	// This and others are similar but we need to call `recover` here because
 	// how it works with defer.

--- a/err2.go
+++ b/err2.go
@@ -246,14 +246,13 @@ func Returnf(err *error, format string, args ...any) {
 	})
 }
 
-func doTrace(err error)  {
+func doTrace(err error) {
 	if err == nil || err.Error() == "" {
 		return
 	}
 	if ErrorTracer() != nil {
-		fmt.Fprint(ErrorTracer(), "===========", err.Error())
+		fmt.Fprint(ErrorTracer(), err.Error())
 	} else if PanicTracer() != nil {
 		fmt.Fprint(PanicTracer(), err.Error())
 	}
 }
-

--- a/err2_test.go
+++ b/err2_test.go
@@ -237,9 +237,7 @@ func TestPanicking_Catch(t *testing.T) {
 }
 
 func TestCatch_Error(t *testing.T) {
-	defer err2.Catch(func(err error) {
-		// fmt.Printf("error and defer handling:%s\n", err)
-	})
+	defer err2.Catch()
 
 	try.To1(throw())
 

--- a/err2_test.go
+++ b/err2_test.go
@@ -60,7 +60,7 @@ func TestPanickingCatchAll(t *testing.T) {
 		{"general panic",
 			args{
 				func() {
-					defer err2.CatchAll(func(err error) {}, func(v any) {})
+					defer err2.Catch(func(err error) {}, func(v any) {})
 					panic("panic")
 				},
 			},
@@ -69,7 +69,7 @@ func TestPanickingCatchAll(t *testing.T) {
 		{"runtime.error panic",
 			args{
 				func() {
-					defer err2.CatchAll(func(err error) {}, func(v any) {})
+					defer err2.Catch(func(err error) {}, func(v any) {})
 					var b []byte
 					b[0] = 0
 				},
@@ -242,6 +242,27 @@ func TestCatch_Error(t *testing.T) {
 	try.To1(throw())
 
 	t.Fail() // If everything works we are newer here
+}
+
+func TestCatch_Panic(t *testing.T) {
+	panicHandled := false
+	defer func() {
+		// when err2.Catch's panic handler works fine, panic is handled
+		if !panicHandled {
+			t.Fail()
+		}
+	}()
+
+	defer err2.Catch(
+		func(err error) {
+			t.Log("it was panic, not an error")
+			t.Fail() // we should not be here
+		},
+		func(v any) {
+			panicHandled = true
+		})
+
+	panic("test panic")
 }
 
 func TestSetErrorTracer(t *testing.T) {

--- a/err2_test.go
+++ b/err2_test.go
@@ -89,47 +89,6 @@ func TestPanickingCatchAll(t *testing.T) {
 	}
 }
 
-func TestPanickingCatchTrace(t *testing.T) {
-	type args struct {
-		f func()
-	}
-	tests := []struct {
-		name  string
-		args  args
-		wants error
-	}{
-		{"general panic",
-			args{
-				func() {
-					defer err2.CatchTrace(func(err error) {})
-					panic("panic")
-				},
-			},
-			nil,
-		},
-		{"runtime.error panic",
-			args{
-				func() {
-					defer err2.CatchTrace(func(err error) {})
-					var b []byte
-					b[0] = 0
-				},
-			},
-			nil,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			defer func() {
-				if recover() != nil {
-					t.Error("panics should NOT carry on when tracing")
-				}
-			}()
-			tt.args.f()
-		})
-	}
-}
-
 func TestPanickingCarryOn_Handle(t *testing.T) {
 	type args struct {
 		f func()

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/lainio/err2
 
-go 1.18
+go 1.19
 
 require golang.org/x/exp v0.0.0-20230105202349-8879d0199aa3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/lainio/err2
 
 go 1.18
+
+require golang.org/x/exp v0.0.0-20230105202349-8879d0199aa3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20230105202349-8879d0199aa3 h1:fJwx88sMf5RXwDwziL0/Mn9Wqs+efMSo/RYcL+37W9c=
+golang.org/x/exp v0.0.0-20230105202349-8879d0199aa3/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -226,6 +226,8 @@ func PreProcess(info *Info, a ...any) {
 			info.Args = a[1:]
 		case NilHandler:
 			info.NilHandler = first
+		case nil:
+			info.NilHandler = NilNoop
 		default:
 			// we don't panic because we can already be in recovery, but lets
 			// try to show an error message at least.

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -204,6 +204,8 @@ func WorkToDo(r any, err *error) bool {
 
 // Process executes error handling logic. Panics and whole defer stack is
 // included.
+//
+// NOTE! That there is an error or a panic to handle i.e. that's taken care.
 func Process(info *Info) {
 	switch info.Any.(type) {
 	case nil:
@@ -217,6 +219,10 @@ func Process(info *Info) {
 	}
 }
 
+// PreProcess is currently used for err2.Handle.
+//
+// NOTE! That there is an error or a panic to handle i.e. that's taken care.
+//
 //nolint:nestif
 func PreProcess(info *Info, a ...any) {
 	if len(a) > 0 {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -254,6 +254,9 @@ func PreProcess(info *Info, a ...any) {
 			}
 		}
 	}
+	if info.PanicHandler == nil && info.CallerName == "Catch" {
+		info.PanicHandler = PanicNoop
+	}
 
 	Process(info)
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -42,6 +42,8 @@ type Info struct {
 	ErrorHandler // If nil default implementation is used.
 
 	PanicHandler // If nil panic() is called.
+
+	CallerName string
 }
 
 const (
@@ -230,6 +232,8 @@ func PreProcess(info *Info, a ...any) {
 		case string:
 			info.Format = first
 			info.Args = a[1:]
+		case ErrorHandler: // err2.Catch uses this
+			info.ErrorHandler = first
 		case NilHandler:
 			info.NilHandler = first
 		case nil:
@@ -246,9 +250,13 @@ func PreProcess(info *Info, a ...any) {
 		// previous AND funcName can search! This is enough:
 		const lvl = -1
 
+		fnName := "Handle"
+		if info.CallerName != "" {
+			fnName = info.CallerName
+		}
 		funcName, _, ok := debug.FuncName(debug.StackInfo{
 			PackageName: "",
-			FuncName:    "Handle", // err2.Handle is anchor
+			FuncName:    fnName, // err2.Handle is anchor
 			Level:       lvl,
 		})
 		if ok {

--- a/internal/str/str.go
+++ b/internal/str/str.go
@@ -39,14 +39,6 @@ func Decamel(s string) string {
 			prevSkipped = skip
 			continue
 		}
-		isUpper = unicode.IsUpper(v)
-		if isUpper {
-			v = unicode.ToLower(v)
-			if !prevSkipped && splittable {
-				b.WriteRune(' ')
-				prevSkipped = true
-			}
-		}
 		toSpace := v == '.' || v == '_'
 		if toSpace {
 			if prevSkipped {
@@ -56,7 +48,16 @@ func Decamel(s string) string {
 				prevSkipped = true
 			}
 		} else {
-			prevSkipped = false
+			isUpper = unicode.IsUpper(v)
+			if isUpper {
+				v = unicode.ToLower(v)
+				if !prevSkipped && splittable {
+					b.WriteRune(' ')
+					prevSkipped = true
+				}
+			} else {
+				prevSkipped = false
+			}
 		}
 		b.WriteRune(v)
 		splittable = !isUpper || unicode.IsNumber(v)

--- a/internal/str/str.go
+++ b/internal/str/str.go
@@ -48,11 +48,13 @@ func Decamel(s string) string {
 			}
 		}
 		toSpace := v == '.' || v == '_'
-		if prevSkipped && toSpace {
-			continue
-		} else if !prevSkipped && toSpace {
-			v = ' '
-			prevSkipped = true
+		if toSpace {
+			if prevSkipped {
+				continue
+			} else {
+				v = ' '
+				prevSkipped = true
+			}
 		} else {
 			prevSkipped = false
 		}

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -1,4 +1,4 @@
-// Package tracer implements thread safe storage for stace trace writers.
+// Package tracer implements thread safe storage for trace writers.
 package tracer
 
 import (

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,6 +1,6 @@
 # Samples
 
-You can play with the samples by editing them and running the main file:
+Please play with the samples by editing them and running the main file:
 ```go
 go run main.go
 ```

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,5 +2,5 @@
 
 You can play with the samples by editing them and running the main file:
 ```go
-sa run main.go
+go run main.go
 ```

--- a/samples/main.go
+++ b/samples/main.go
@@ -46,14 +46,21 @@ func CopyFile(src, dst string) (err error) {
 
 func main() {
 	// To see how automatic stack tracing works.
-	err2.SetErrorTracer(os.Stderr)
+	//err2.SetErrorTracer(os.Stderr)
+	err2.SetPanicTracer(os.Stderr) // for the err2.Catch()
+
 	// to see how there is two predefined formatters and own can be
 	// implemented.
 	err2.SetFormatter(formatter.Noop) // default is formatter.Decamel
 
-	defer err2.Catch(func(err error) {
-		fmt.Println("ERROR:", err)
-	})
+	// even no handlers is given, errors are caught without specific handlers.
+	defer err2.Catch() // thanks to panic tracer error msg is printed!
+
+	// If you don't want to use tracers or you just need proper error handler
+	// here.
+//	defer err2.Catch(func(err error) {
+//		fmt.Println("ERROR:", err)
+//	})
 
 	// You can select anyone of the try.To(CopyFile lines to play with and see
 	// how err2 works. Especially interesting is automatic stack tracing.

--- a/samples/main.go
+++ b/samples/main.go
@@ -58,9 +58,9 @@ func main() {
 
 	// If you don't want to use tracers or you just need proper error handler
 	// here.
-//	defer err2.Catch(func(err error) {
-//		fmt.Println("ERROR:", err)
-//	})
+	//	defer err2.Catch(func(err error) {
+	//		fmt.Println("ERROR:", err)
+	//	})
 
 	// You can select anyone of the try.To(CopyFile lines to play with and see
 	// how err2 works. Especially interesting is automatic stack tracing.

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -146,6 +146,10 @@ replace_annotate() {
 	"$location"/replace-perl.sh 'err2\.(Annotatew\()(.*)(, )(.*)(\)\n)' 'err2.Returnw(\4\3\2\5'
 }
 
+replace_catchtrace() {
+	"$location"/replace-perl.sh 'defer err2\.CatchTrace\(' 'defer err2.Catch('
+}
+
 replace_easy1() {
 	vlog "Replacing err2.Check, err2.FilterTry, err2.TryEOF, and type vars"
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -122,7 +122,7 @@ replace_annotate2() {
 }
 
 replace_return_blain() {
-	"$location"/replace-perl.sh 'defer err2\.Return\(\&err\)' 'defer err2.Handle(&err, func() {})'
+	"$location"/replace-perl.sh 'defer err2\.Return\(\&err\)' 'defer err2.Handle(&err, nil)'
 	"$location"/replace-perl.sh 'defer err2\.Returnf\(' 'defer err2.Handle('
 	"$location"/replace-perl.sh 'defer err2\.Returnw\(' 'defer err2.Handle('
 }

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -128,6 +128,11 @@ replace_return_blain() {
 	"$location"/replace-perl.sh 'defer err2\.Returnw\(' 'defer err2.Handle('
 }
 
+replace_catch() {
+	"$location"/replace-perl.sh 'defer err2\.CatchTrace\(' 'defer err2.Catch('
+	"$location"/replace-perl.sh 'defer err2\.CatchAll\(' 'defer err2.Catch('
+}
+
 replace_return() {
 	"$location"/replace-perl.sh 'defer err2\.Return\(' 'defer err2.Handle('
 	"$location"/replace-perl.sh 'defer err2\.Returnf\(' 'defer err2.Handle('
@@ -138,16 +143,16 @@ replace_tracers() {
 	"$location"/replace-perl.sh 'err2\.(StackTraceWriter = )(.*)' 'err2.SetTracers(\2)'
 }
 
+replace_defasserter() {
+	"$location"/replace-perl.sh 'assert\.(DefaultAsserter = )(.*)' 'assert.SetDefaultAsserter(\2)'
+}
+
 replace_annotate() {
 	# Replace Annotate with Returnf: notice argument order!!
 	"$location"/replace-perl.sh 'err2\.(Annotate\()(.*)(, )(.*)(\)\n)' 'err2.Returnf(\4\3\2\5'
 
 	# Replace Annotatew with Returnf: notice argument order!!
 	"$location"/replace-perl.sh 'err2\.(Annotatew\()(.*)(, )(.*)(\)\n)' 'err2.Returnw(\4\3\2\5'
-}
-
-replace_catchtrace() {
-	"$location"/replace-perl.sh 'defer err2\.CatchTrace\(' 'defer err2.Catch('
 }
 
 replace_easy1() {

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -121,6 +121,12 @@ replace_annotate2() {
 	"$location"/replace-perl.sh 'defer err2\.Annotatew\(' 'defer err2.Handle('
 }
 
+replace_return_blain() {
+	"$location"/replace-perl.sh 'defer err2\.Return\(\&err\)' 'defer err2.Handle(&err, func() {})'
+	"$location"/replace-perl.sh 'defer err2\.Returnf\(' 'defer err2.Handle('
+	"$location"/replace-perl.sh 'defer err2\.Returnw\(' 'defer err2.Handle('
+}
+
 replace_return() {
 	"$location"/replace-perl.sh 'defer err2\.Return\(' 'defer err2.Handle('
 	"$location"/replace-perl.sh 'defer err2\.Returnf\(' 'defer err2.Handle('

--- a/scripts/migr-name.sh
+++ b/scripts/migr-name.sh
@@ -33,7 +33,7 @@ while getopts 'dnvoumh:' OPTION; do
 		vlog "migration_branch = $OPTARG"
 		;;
 	h)
-		egrep '^.*\(\) \{' $location/functions.sh | egrep $OPTARG
+		egrep '^.*\(\) \{' $location/functions.sh | egrep $OPTARG | sed -E 's/\(\) \{//g'
 		exit 1
 		;;
 	?)

--- a/scripts/migr-name.sh
+++ b/scripts/migr-name.sh
@@ -6,7 +6,7 @@ location=$(dirname "$BASH_SOURCE")
 set -e
 
 # =================== main =====================
-while getopts 'dnvoum:' OPTION; do
+while getopts 'dnvoumh:' OPTION; do
 	case "$OPTION" in
 	n)
 		vlog "no commits"
@@ -32,9 +32,14 @@ while getopts 'dnvoum:' OPTION; do
 		migration_branch="$OPTARG"
 		vlog "migration_branch = $OPTARG"
 		;;
+	h)
+		egrep '^.*\(\) \{' $location/functions.sh | egrep $OPTARG
+		exit 1
+		;;
 	?)
 		echo "usage: $(basename $0) [-n] [-v] [-o] [-u] [-m runmode] [functions...]" >&2
 		echo "       n: no commit" >&2
+		echo "       h: print functions" >&2
 		echo "       d: add debug output" >&2
 		echo "       v: verbose" >&2
 		echo "       o: only simple migrations" >&2
@@ -48,7 +53,9 @@ shift "$(($OPTIND -1))"
 
 migration_branch=${migration_branch:-"err2-auto-update"}
 no_commit=${no_commit:-"1"}
-start_branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ $no_commit != "1" ]]; then
+	start_branch=$(git rev-parse --abbrev-ref HEAD)
+fi
 use_current_branch=${use_current_branch:-""}
 only_simple=${only_simple:-""}
 

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -72,6 +72,7 @@ commit "commit deps"
 echo "====== basic err2 refactoring ===="
 echo "processing..."
 
+replace_catchtrace
 replace_tracers
 replace_annotate
 replace_return

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -72,8 +72,9 @@ commit "commit deps"
 echo "====== basic err2 refactoring ===="
 echo "processing..."
 
-replace_catchtrace
+replace_catch
 replace_tracers
+replace_defasserter
 replace_annotate
 replace_return
 replace_easy1

--- a/snippets/go.json
+++ b/snippets/go.json
@@ -1,0 +1,30 @@
+{
+	".source.go": {
+		"defer err2.Handle": {
+			"prefix": "eha",
+			"body": "defer err2.Handle(&err)\n\n",
+			"description": "Snippet for err2.Handle(&err)"
+		},
+		"defer err2.Handle nil": {
+			"prefix": "ehan",
+			"body": "defer err2.Handle(&err, nil)\n\n",
+			"description": "Snippet for err2.Handle(&err, nil)"
+		},
+		"defer err2.Handle func": {
+			"prefix": "ehaf",
+			"body": "defer err2.Handle(&err, func() {\n\t$0\n})\n\n",
+			"description": "Snippet for err2.Handle(&err, func() {})"
+		},
+		"assert.Push&PopTester()": {
+			"prefix": "aspu",
+			"body": "assert.PushTester(${1:t})\ndefer assert.PopTester()\n\n",
+			"description": "Snippet for pushing current tester"
+		},
+		"assert.That()": {
+			"prefix": "asth",
+			"body": "assert.That(${1:bool}$2)",
+			"description": "Snippet for pushing current tester"
+		}
+	}
+}
+

--- a/snippets/go.json
+++ b/snippets/go.json
@@ -2,22 +2,22 @@
 	".source.go": {
 		"defer err2.Handle": {
 			"prefix": "eha",
-			"body": "defer err2.Handle(&err)\n\n",
+			"body": "defer err2.Handle(&err)\n",
 			"description": "Snippet for err2.Handle(&err)"
 		},
 		"defer err2.Handle nil": {
 			"prefix": "ehan",
-			"body": "defer err2.Handle(&err, nil)\n\n",
+			"body": "defer err2.Handle(&err, nil)\n",
 			"description": "Snippet for err2.Handle(&err, nil)"
 		},
 		"defer err2.Handle func": {
 			"prefix": "ehaf",
-			"body": "defer err2.Handle(&err, func() {\n\t$0\n})\n\n",
+			"body": "defer err2.Handle(&err, func() {\n\t$0\n})\n",
 			"description": "Snippet for err2.Handle(&err, func() {})"
 		},
 		"assert.Push&PopTester()": {
 			"prefix": "aspu",
-			"body": "assert.PushTester(${1:t})\ndefer assert.PopTester()\n\n",
+			"body": "assert.PushTester(${1:t})\ndefer assert.PopTester()\n",
 			"description": "Snippet for pushing current tester"
 		},
 		"assert.That()": {

--- a/try/notfound_test.go
+++ b/try/notfound_test.go
@@ -31,8 +31,8 @@ func ExampleIsNotFound1() {
 		defer err2.Catch(func(err error) {
 			fmt.Println("ERROR:", err)
 		})
-		found, value := try.IsNotFound1(FindObject(key))
-		if found {
+		notFound, value := try.IsNotFound1(FindObject(key))
+		if notFound {
 			return fmt.Sprintf("cannot find key (%d)", key)
 		}
 		return "value for key is:" + value

--- a/try/try.go
+++ b/try/try.go
@@ -54,7 +54,7 @@ func To(err error) {
 	}
 }
 
-// To1 is a helper function to call functions which returns (any, error)
+// To1 is a helper function to call functions which returns (T, error)
 // and check the error value. If an error occurs, it panics the error where err2
 // handlers can catch it if needed.
 func To1[T any](v T, err error) T {
@@ -62,7 +62,7 @@ func To1[T any](v T, err error) T {
 	return v
 }
 
-// To2 is a helper function to call functions which returns (any, any, error)
+// To2 is a helper function to call functions which returns (T, U, error)
 // and check the error value. If an error occurs, it panics the error where err2
 // handlers can catch it if needed.
 func To2[T, U any](v1 T, v2 U, err error) (T, U) {
@@ -70,7 +70,7 @@ func To2[T, U any](v1 T, v2 U, err error) (T, U) {
 	return v1, v2
 }
 
-// To3 is a helper function to call functions which returns (any, any, any, error)
+// To3 is a helper function to call functions which returns (T, U, V, error)
 // and check the error value. If an error occurs, it panics the error where err2
 // handlers can catch it if needed.
 func To3[T, U, V any](v1 T, v2 U, v3 V, err error) (T, U, V) {


### PR DESCRIPTION
- new migration function for Return sentinel error values
- correct second argument for sentinel error return
- err2.Handle can return sentinel errors by disabling automatic annotation
- linter
- typo: sa -> go
- TestMain is now safe in migration, defer linter added, typos
- -h flag can output functions to call
- rename wrong varible name: now notFound
- new number assert started (Zero), constraint module dep
- cleanup migr-name.sh -h search output
- value -> pointer for proper documentation
- GO variable to Makefile with default
- first version of err2 vc-code formatet snippets which work on vim too
- version comment, and code snippets mention
- Badges test
- badge
- remove badges
- documentation update
- deprecate CatchTrace
- decamel str pkg optimization & readability
- Decamel optimizations lead to more nested ifs (false posit)
- more optimizations to Decamel, almost same with Go 1.20rc3 now
- missing mutex for the map, Len() added, corret defaults, ..
- more documentation and typo fixes
- snippets had extra line feeds
- SetDefaultAsserter(a) instead of var for thread safety
- Catch api is (...) now
- making empty Catch work without crash
- testing Catch's new API
- lots of new documentation and tracing for empty Catch
- PreProcess supports Catch and maybe got new features to Handle as well
- extending sample for new Catch API
- better wording
- gofmt
- go version to 1.19
- linter fight, bug in 1.51.1
- documentation and linefeed for Catch tracing
- lots of new tests for Handle and Catch for panics
- stop panics
- Catch and default asserter migrations
- New version history format
- new benchmark io.Copy vs. our loop
- better Go documentation
- linter for new bench
- use try.To not shutdown errors
- new Go documentation for assert pkg
- more readme documentation
- bold the backward compatibility promise aka auto-migration
