### PR TITLE
auto wrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IDEs, etc.
 .idea
 Session.vim*
+coverage.*
 
 # Binaries for programs and plugins
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ bench_arec:
 	$(GO) test -bench='BenchmarkRecursion.*' $(PKG1)
 
 bench_copy:
-	$(GO) test -bench='Benchmark_CopyBuffer' $(PKG1)
+	$(GO) test -bench='Benchmark_CopyBuffer' $(PKG3)
 
 bench_rec:
 	$(GO) test -bench='BenchmarkRecursionWithOldErrorIfCheckAnd_Defer' $(PKG1)

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,8 @@ test_cov_out:
 		./...
 
 test_cov: test_cov_out
-	go tool cover -html=coverage.txt
+	go tool cover -html=coverage.txt -o=coverage.html
+	firefox ./coverage.html 1>&- 2>&-  &
 
 lint:
 	@golangci-lint run

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![test](https://github.com/lainio/err2/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/lainio/err2/actions/workflows/test.yml)
-[![GoDev](https://img.shields.io/static/v1?label=godev&message=reference&color=00add8)][godev]
+![Go Version](https://img.shields.io/badge/go%20version-%3E=1.19-61CFDD.svg?style=flat-square)
+[![PkgGoDev](https://pkg.go.dev/badge/mod/github.com/lainio/err2)](https://pkg.go.dev/mod/github.com/lainio/err2)
 [![Go Report Card](https://goreportcard.com/badge/github.com/lainio/err2?style=flat-square)](https://goreportcard.com/report/github.com/lainio/err2)
 
 # err2

--- a/README.md
+++ b/README.md
@@ -228,10 +228,10 @@ default asserter with the following line:
 SetDefaultAsserter(AsserterToError) // we offer separated flags for caller info
 ```
 
-For certain type programs this is the best way. It allows us to keep all the
+For certain type of programs this is the best way. It allows us to keep all the
 error messages as simple as possible. And by offering option to turn additional
-information on, allows super users and developers get more technical information
-when needed.
+information on, which allows super users and developers get more technical
+information when needed.
 
 #### Assertion Package for Runtime Use
 
@@ -246,12 +246,12 @@ func marshalAttestedCredentialData(json []byte, data *protocol.AuthenticatorData
 ```
 
 We have now described design-by-contract for development and runtime use. What
-makes err2's assertion packages unique and extremely powerful is its use for
+makes err2's assertion packages unique, and extremely powerful, is its use for
 automatic testing as well.
 
 #### Assertion Package for Unit Testing
 
-The same asserts can be used during the unit tests:
+The same asserts can be used **and shared** during the unit tests:
 
 ```go
 func TestWebOfTrustInfo(t *testing.T) {
@@ -278,11 +278,13 @@ Especially powerful feature is that even if some assertion violation happens
 during the execution of called functions like above `NewWebOfTrust()` function
 instead of the actual Test function, **it's reported as normal test failure.**
 That means that we don't need to open our internal pre- and post-conditions just
-for testing.
+for testing. **We can share the same assertions between runtime and test
+execution.**
 
 Only minus is that test coverage figures are too conservatives. The code that
 uses design-by-contract assertions is typically much more robust what the actual
-test coverage results tell you.
+test coverage results tell you. However, this's well know problem with test
+coverage metric in generally.
 
 ## Code Snippets
 
@@ -344,7 +346,7 @@ than getting unrelated panic somewhere else in the code later. There have also
 been cases when code reports error correctly because the 'upper' handler catches
 it.
 
-- Because the use of `err2.Handle` is so easy, error messages much are better
+- Because the use of `err2.Handle` is so easy, error messages are much better
 and informative. When using `err2.Handle`'s automatic annotation your error
 messages are always up-to-date. Even when you refactor your function name error
 message is also updated.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ func CopyFile(src, dst string) (err error) {
 - [Backwards Compatibility Promise for the API](#backwards-compatibility-promise-for-the-api)
 - [Assertion](#assertion)
   - [Assertion Package for Unit Testing](#assertion-package-for-unit-testing)
+  - [Assertion Package for Runtime Use](#assertion-package-for-runtime-use)
 - [Code Snippets](#code-snippets)
 - [Background](#background)
 - [Learnings by so far](#learnings-by-so-far)
@@ -204,7 +205,7 @@ More information can be found from scripts' [readme file](./scripts/README.md).
 
 ## Assertion
 
-The `assert` package is meant to be used for **design-by-contract-**type of
+The `assert` package is meant to be used for *design-by-contract-* type of
 development where you set pre- and post-conditions for your functions. It's not
 meant to replace the normal error checking but speed up the incremental hacking
 cycle. The default mode is to return an `error` value that includes formatted
@@ -231,6 +232,8 @@ For certain type programs this is the best way. It allows us to keep all the
 error messages as simple as possible. And by offering option to turn additional
 information on, allows super users and developers get more technical information
 when needed.
+
+#### Assertion Package for Runtime Use
 
 Following is example of use of the assert package:
 
@@ -259,8 +262,8 @@ func TestWebOfTrustInfo(t *testing.T) {
 	assert.SLen(common, 2)
 
 	wot := dave.WebOfTrustInfo(eve.Node) //<- this includes asserts as well!!
-    // and if there's violations during the test run they are reported as 
-    // test failures.
+	// And if there's violations during the test run they are reported as 
+	// test failures for this TestWebOfTrustInfo -test.
 
 	assert.Equal(0, wot.CommonInvider)
 	assert.Equal(1, wot.Hops)
@@ -274,8 +277,12 @@ func TestWebOfTrustInfo(t *testing.T) {
 Especially powerful feature is that even if some assertion violation happens
 during the execution of called functions like above `NewWebOfTrust()` function
 instead of the actual Test function, **it's reported as normal test failure.**
-That means that we don't need to open our internal preconditions just for
-testing.
+That means that we don't need to open our internal pre- and post-conditions just
+for testing.
+
+Only minus is that test coverage figures are too conservatives. The code that
+uses design-by-contract assertions is typically much more robust what the actual
+test coverage results tell you.
 
 ## Code Snippets
 
@@ -457,8 +464,8 @@ GitHub Discussions. Naturally, any issues are welcome as well!
 ### Upcoming releases
 
 ##### 0.9.1
-- More support for `assert` package for tests
+- More support for `assert` package for tests: plugins like nvim-go
 - More support for wrapping multiple errors
 
 ##### 0.9.2 
-- More documentation, reparing for some sort of margeting
+- More documentation, reparing for some sort of marketing

--- a/README.md
+++ b/README.md
@@ -199,13 +199,35 @@ More information can be found from scripts' [readme file](./scripts/README.md).
 
 ## Assertion
 
-The `assert` package is meant to be used for design-by-contract-type of
-development where you set preconditions for your functions. It's not meant to
-replace normal error checking but speed up incremental hacking cycle. That's the
-reason why default mode is to return `error` value that includes formatted and
-detailed assertion violation message. A developer get immediate and proper
-feedback which allows cleanup the code and APIs before actual production
-release.
+The `assert` package is meant to be used for **design-by-contract-**type of
+development where you set pre- and post-conditions for your functions. It's not
+meant to replace the normal error checking but speed up the incremental hacking
+cycle. The default mode is to return an `error` value that includes formatted
+and detailed assertion violation message. A developer get immediate and proper
+feedback which allows cleanup the code and APIs before actual release.
+
+The assert package offers a few pre-build *asserters*, which are used to
+configure how assert package deals with assert violations. The line below is
+example how the default asserter is set in the package.
+
+```go
+SetDefaultAsserter(AsserterToError | AsserterFormattedCallerInfo)
+```
+
+If you want to suppress the caller info (source file name, line number, etc.)
+and get just the plain error messages from the asserts, you should set the
+default asserter with the following line:
+
+```go
+SetDefaultAsserter(AsserterToError) // we offer separated flags for caller info
+```
+
+For certain type programs this is the best way. It allows us to keep all the
+error messages as simple as possible. And by offering option to turn additional
+information on, allows super users and developers get more technical information
+when needed.
+
+Following is example of use of the assert package:
 
 ```go
 func marshalAttestedCredentialData(json []byte, data *protocol.AuthenticatorData) []byte {
@@ -215,15 +237,9 @@ func marshalAttestedCredentialData(json []byte, data *protocol.AuthenticatorData
 	...
 ```
 
-Previous code block shows the use of the asserter package for developing.
-
-The assert package offers a few pre-build `Asserter`. The asserters are used to
-configure how assert package deals assert violations. The line below is example
-how the default asserter is set.
-
-```go
-SetDefaultAsserter(AsserterToError | AsserterFormattedCallerInfo)
-```
+We have now described design-by-contract for development and runtime use. What
+makes err2's assertion packages unique and extremely powerful is its use for
+automatic testing as well.
 
 #### Assertion Package for Unit Testing
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ func CopyFile(src, dst string) (err error) {
 }
 ```
 
+[![test](https://github.com/lainio/err2/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/lainio/err2/actions/workflows/test.yml)
+
 `go get github.com/lainio/err2`
 
 - [Structure](#structure)
@@ -446,7 +448,7 @@ GitHub Discussions. Naturally, any issues are welcome as well!
     - Only `err2.Handle` for error returning functions
     - Only `err2.Catch` for function that doesn't return error
     - Please see `scripts/README.md' for *Auto-migration for your repos*
-- `err2.SetPanicTracer(os.Stderr)` is default now
+- Default `err2.SetPanicTracer(os.Stderr)` allows `defer err2.Catch()`
 
 
 ### Upcoming releases

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ performance tests to measure the effect. As a general guideline for maximum
 performance we recommend to put error handlers as high in the call stack as
 possible, and use only error checking (`try.To()` calls) in the inner loops. And
 yes, that leads to non-local control structures, but it's the most performant
-solution of all. (The repo has benchmarks for that as well)
+solution of all. (The repo has benchmarks for that as well.)
 
 The original goal was to make it possible to write similar code that the
 proposed Go2 error handling would allow and do it right now (summer 2019). The
@@ -377,7 +377,8 @@ GitHub Discussions. Naturally, any issues are welcome as well!
 - `assert` package added, and new type helpers
 ##### 0.7.0
 - filter functions for non-errors like `io.EOF`
-##### 0.8.0
+
+#### 0.8.0
 - `try.To()`, **Start to use Go generics**
 - `assert.That()` and other assert functions with the help of the generics
 ##### 0.8.1
@@ -428,12 +429,17 @@ GitHub Discussions. Naturally, any issues are welcome as well!
 - **Code snippets** added
 - New assertion functions
 - no direct variables in APIs (race), etc.
-##### 0.8.15
-- `err2.SetPanicTracer(os.Stderr)` must be default 'cause we stop panics now
+
+#### 0.9.0 Clean API 
+- removigin deprecated functions from API
+    - only `err2.Handle` for error returning functions
+    - only `err2.Catch` for function that doesn't return error
+- `err2.SetPanicTracer(os.Stderr)` is default now
+
 
 ### Upcoming releases
 
-##### 0.9.0 Clean API: only `err2.Handle` for error returning functions.
-##### 0.9.1 Clean API: `err2.CatchXXX` type assertions or many functions?
-- done in version 0.8.14
-##### 0.9.2 Clean API: preparing to release 1.0.0 and freeze the API
+##### 0.9.1 
+- more support for wrapping multiple errors
+##### 0.9.2 
+- more documentation, reparing for some sort of margeting

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![test](https://github.com/lainio/err2/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/lainio/err2/actions/workflows/test.yml)
+[![GoDev](https://img.shields.io/static/v1?label=godev&message=reference&color=00add8)][godev]
+[![Go Report Card](https://goreportcard.com/badge/github.com/lainio/err2?style=flat-square)](https://goreportcard.com/report/github.com/lainio/err2)
+
 # err2
 
 The package extends Go's error handling with **fully automatic error
@@ -26,8 +30,6 @@ func CopyFile(src, dst string) (err error) {
 	return nil
 }
 ```
-
-[![test](https://github.com/lainio/err2/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/lainio/err2/actions/workflows/test.yml)
 
 `go get github.com/lainio/err2`
 

--- a/README.md
+++ b/README.md
@@ -355,82 +355,105 @@ GitHub Discussions. Naturally, any issues are welcome as well!
 ### Version history
 
 ##### 0.1
-- first draft (Summer 2019)
+- First draft (Summer 2019)
+
 ##### 0.2
-- code generation for type helpers
+- Code generation for type helpers
+
 ##### 0.3
 - `Returnf` added, not use own transport type anymore but just `error`
+
 ##### 0.4
 - Documentation update
+
 ##### 0.5
 - Go modules are in use
+
 ##### 0.6.1
 - `assert` package added, and new type helpers
+
 ##### 0.7.0
-- filter functions for non-errors like `io.EOF`
+- Filter functions for non-errors like `io.EOF`
 
 #### 0.8.0
 - `try.To()`, **Start to use Go generics**
 - `assert.That()` and other assert functions with the help of the generics
+
 ##### 0.8.1
 - **bug-fix**: `runtime.Error` types are treated as `panics` now (Issue #1)
+
 ##### 0.8.3
 - `try.IsXX()` bug fix
 - Lots of new docs
 - **Automatic Stack Tracing!**
+
 ##### 0.8.4
 - **Optimized** Stack Tracing
 - Documentation
 - Benchmarks, other tests
+
 ##### 0.8.5
 - Typo in `StackTraceWriter` fixed
+
 ##### 0.8.6
 - Stack Tracing bug fixed
 - URL helper restored until migration tool
+
 ##### 0.8.7
 - **Auto-migration tool** to convert deprecated API usage for your repos
 - `err2.Throwf` added
+
 ##### 0.8.8
 - **Assertion package integrates with Go's testing system**
 - Type variables removed
+
 ##### 0.8.9
-- Bug fixes
-- deprecations
-- new Tracer API
-- preparing `err2` API for 1.0
+- bug fixes
+- Deprecations
+- New Tracer API
+- Preparing `err2` API for 1.0
+
 ##### 0.8.10
 - New assertion functions and helpers for tests
+
 ##### 0.8.11
-- Remove deprecations
-- new *global* err values and `try.IsXX` functions
-- more documentation
+- remove deprecations
+- New *global* err values and `try.IsXX` functions
+- More documentation
+
 ##### 0.8.12
 - New super **Handle** for most of the use cases to simplify the API
-- **deferred error handlers are 2x faster now**
-- restructuring internal pkgs
-- new documentation and tests, etc.
+- **Deferred error handlers are 2x faster now**
+- Restructuring internal pkgs
+- New documentation and tests, etc.
+
 ##### 0.8.13
 - **Bug-fix:** automatic error strings for methods
-- added API to set preferred error string *Formatter* or implement own
+- Added API to set preferred error string *Formatter* or implement own
+
 ##### 0.8.14
 - `err2.Handle` supports sentinel errors, can now stop panics
 - `err2.Catch` has one generic API and it stops panics as default
-- deprecated `CatchTrace` and CatchAll` which merged with `Catch`
+- Deprecated `CatchTrace` and `CatchAll` which merged with `Catch`
 - Auto-migration offered (similar to `go fix`)
 - **Code snippets** added
 - New assertion functions
-- no direct variables in APIs (race), etc.
+- No direct variables in APIs (race), etc.
 
-#### 0.9.0 Clean API 
-- removigin deprecated functions from API
-    - only `err2.Handle` for error returning functions
-    - only `err2.Catch` for function that doesn't return error
+#### 0.9.0
+- **Clean and simple API** 
+- Removing deprecated functions:
+    - Only `err2.Handle` for error returning functions
+    - Only `err2.Catch` for function that doesn't return error
+    - Please see `scripts/README.md' for *Auto-migration for your repos*
 - `err2.SetPanicTracer(os.Stderr)` is default now
 
 
 ### Upcoming releases
 
-##### 0.9.1 
-- more support for wrapping multiple errors
+##### 0.9.1
+- More support for `assert` package for tests
+- More support for wrapping multiple errors
+
 ##### 0.9.2 
-- more documentation, reparing for some sort of margeting
+- More documentation, reparing for some sort of margeting

--- a/README.md
+++ b/README.md
@@ -76,19 +76,19 @@ of the change. And, of course, it helps to make your code error-safe:
 
 The err2 package is your automation buddy:
 
-1. It helps to declare error handlers with `defer`. If you're familiar [Zig
-   language](https://ziglang.org/) you can think `defer err2.Handle(&err,...)`
+1. It helps to declare error handlers with `defer`. If you're familiar with [Zig
+   language](https://ziglang.org/), you can think `defer err2.Handle(&err,...)`
    line exactly similar as
    [Zig's `errdefer`](https://ziglang.org/documentation/master/#errdefer).
 2. It helps to check and transport errors to the nearest (the defer-stack) error
    handler. 
 3. It helps us use design-by-contract type preconditions.
 4. It offers automatic stack tracing for every error, runtime error, or panic.
-   If you are familiar to Zig, the `err2` error traces are same as Zig's.
+   If you are familiar with Zig, the `err2` error traces are same as Zig's.
 
 You can use all of them or just the other. However, if you use `try` for error
-checks you must remember use Go's `recover()` by yourself, or your error isn't
-transformed to an `error` return value at any point.
+checks, you must remember to use Go's `recover()` by yourself, or your error
+isn't transformed to an `error` return value at any point.
 
 ## Error handling
 
@@ -96,10 +96,10 @@ The `err2` relies on Go's declarative programming structure `defer`. The
 `err2` helps to set deferred functions (error handlers) which are only called if
 `err != nil`.
 
-In every function which uses err2 for error-checking should have at least one
-error handler. If there are no error handlers and error occurs the current
-function panics. However, if *any* function above in the call stack has `err2`
-error handler it will catch the error.
+Every function which uses err2 for error-checking should have at least one error
+handler. The current function panics if there are no error handlers and an error
+occurs. However, if *any* function above in the call stack has an err2 error
+handler, it will catch the error.
 
 This is the simplest form of `err2` automatic error handler:
 
@@ -109,18 +109,17 @@ func doSomething() (err error) {
     defer err2.Handle(&err) 
 ```
 
-See more information from `err2.Handle`'s documentation. It support several
-error handling scenarios. And remember that you can have as many error handlers
+See more information from `err2.Handle`'s documentation. It supports several
+error-handling scenarios. And remember that you can have as many error handlers
 per function as you need.
 
 #### Error Stack Tracing
 
 The err2 offers optional stack tracing. It's automatic and optimized. Optimized
-means that call stack is processed before output. That means that stack trace
-starts from where the actual error/panic is occurred and not from where the
-error is caught. You don't need to search your self the actual line where the
-pointer was nil or error was received. That line is in the first one you are
-seeing:
+means that the call stack is processed before output. That means that stack
+trace starts from where the actual error/panic is occurred, not where the error
+is caught. You don't need to search for the line where the pointer was nil or
+received an error. That line is in the first one you are see:
 
 ```console
 ---
@@ -194,27 +193,27 @@ For more information see the examples in the documentation of both functions.
 
 ## Backwards Compatibility Promise for the API
 
-The `err2` package's API will be **backwards compatible**. Before the version
-1.0.0 is released the API changes time to time, but **we promise to offer
+The `err2` package's API will be **backward compatible**. Before version
+1.0.0 is released, the API changes occasionally, but **we promise to offer
 automatic conversion scripts for your repos to update them for the latest API.**
-We also mark functions deprecated before they become obsolete. Usually one
-released version before. We have tested this in our systems with large code base
-and it works wonderfully.
+We also mark functions deprecated before they become obsolete. Usually, one
+released version before. We have tested this with a large code base in our
+systems, and it works wonderfully.
 
-More information can be found from scripts' [readme file](./scripts/README.md).
+More information can be found in the scripts' [readme file](./scripts/README.md).
 
 ## Assertion
 
 The `assert` package is meant to be used for *design-by-contract-* type of
 development where you set pre- and post-conditions for your functions. It's not
 meant to replace the normal error checking but speed up the incremental hacking
-cycle. The default mode is to return an `error` value that includes formatted
-and detailed assertion violation message. A developer get immediate and proper
-feedback which allows cleanup the code and APIs before actual release.
+cycle. The default mode is to return an `error` value that includes a formatted
+and detailed assertion violation message. A developer gets immediate and proper
+feedback, allowing cleanup of the code and APIs before the release.
 
 The assert package offers a few pre-build *asserters*, which are used to
-configure how assert package deals with assert violations. The line below is
-example how the default asserter is set in the package.
+configure how the assert package deals with assert violations. The line below
+exemplifies how the default asserter is set in the package.
 
 ```go
 SetDefaultAsserter(AsserterToError | AsserterFormattedCallerInfo)
@@ -274,17 +273,17 @@ func TestWebOfTrustInfo(t *testing.T) {
 	...
 ```
 
-Especially powerful feature is that even if some assertion violation happens
-during the execution of called functions like above `NewWebOfTrust()` function
-instead of the actual Test function, **it's reported as normal test failure.**
-That means that we don't need to open our internal pre- and post-conditions just
-for testing. **We can share the same assertions between runtime and test
+A compelling feature is that even if some assertion violation happens during the
+execution of called functions like the above `NewWebOfTrust()` function instead
+of the actual Test function, **it's reported as a standard test failure.** That
+means we don't need to open our internal pre- and post-conditions just for
+testing. **We can share the same assertions between runtime and test
 execution.**
 
-Only minus is that test coverage figures are too conservatives. The code that
+The only minus is that test coverage figures are too conservative. The code that
 uses design-by-contract assertions is typically much more robust what the actual
-test coverage results tell you. However, this's well know problem with test
-coverage metric in generally.
+test coverage results tell you. However, this's a well-known problem with test
+coverage metric in general.
 
 ## Code Snippets
 
@@ -352,7 +351,9 @@ messages are always up-to-date. Even when you refactor your function name error
 message is also updated.
 
 - **When error handling is based on the actual error handlers, code changes have
-been much easier.**
+been much easier.** There is an excellent [blog post](https://jesseduffield.com/Gos-Shortcomings-1/)
+about the issues you are facing with Go's error handling without the help of
+the err2 package.
 
 - You don't seem to need '%w' wrapping. See the Go's official blog post what are
 [cons](https://go.dev/blog/go1.13-errors) for that.

--- a/README.md
+++ b/README.md
@@ -428,6 +428,8 @@ GitHub Discussions. Naturally, any issues are welcome as well!
 - **Code snippets** added
 - New assertion functions
 - no direct variables in APIs (race), etc.
+##### 0.8.15
+- `err2.SetPanicTracer(os.Stderr)` must be default 'cause we stop panics now
 
 ### Upcoming releases
 

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -103,7 +103,7 @@ func ThatNot(term bool, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := "ThatNot: "+assertionMsg
+		defMsg := "ThatNot: " + assertionMsg
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -116,7 +116,7 @@ func That(term bool, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := "That: "+assertionMsg
+		defMsg := "That: " + assertionMsg
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -92,7 +92,7 @@ func tester() testing.TB {
 
 // NotImplemented always panics with 'not implemented' assertion message.
 func NotImplemented(a ...any) {
-	D.reportAssertionFault("not implemented", a...)
+	DefaultAsserter().reportAssertionFault("not implemented", a...)
 }
 
 // ThatNot asserts that the term is NOT true. If is it panics with the given

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -92,6 +92,9 @@ func tester() testing.TB {
 
 // NotImplemented always panics with 'not implemented' assertion message.
 func NotImplemented(a ...any) {
+	if DefaultAsserter().isUnitTesting() {
+		tester().Helper()
+	}
 	DefaultAsserter().reportAssertionFault("not implemented", a...)
 }
 
@@ -224,7 +227,7 @@ func NotEqual[T comparable](val, want T, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := fmt.Sprintf(assertionMsg+": got %v, want different", val)
+		defMsg := fmt.Sprintf(assertionMsg+": got %v want (!= %v)", val, want)
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -263,7 +266,7 @@ func NotDeepEqual(val, want any, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := fmt.Sprintf(assertionMsg+": got %v, want different", val)
+		defMsg := fmt.Sprintf(assertionMsg+": got %v, want (!= %v)", val, want)
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -422,7 +425,20 @@ func Zero[T Number](val T, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": value isn't zero"
+		defMsg := fmt.Sprintf(assertionMsg+": got %v, want (== 0)", val)
+		DefaultAsserter().reportAssertionFault(defMsg, a...)
+	}
+}
+
+// NotZero asserts that the value != 0. If it is not it panics with the given
+// formatting string. Thanks to inlining, the performance penalty is equal to a
+// single 'if-statement' that is almost nothing.
+func NotZero[T Number](val T, a ...any) {
+	if val == 0 {
+		if DefaultAsserter().isUnitTesting() {
+			tester().Helper()
+		}
+		defMsg := fmt.Sprintf(assertionMsg+": got %v, want (!= 0)", val)
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -103,7 +103,7 @@ func ThatNot(term bool, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg
+		defMsg := "ThatNot: "+assertionMsg
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -116,7 +116,7 @@ func That(term bool, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg
+		defMsg := "That: "+assertionMsg
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -128,7 +128,7 @@ func NotNil[T any](p *T, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": pointer is nil"
+		defMsg := assertionMsg + ": pointer shouldn't be nil"
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -140,7 +140,7 @@ func Nil[T any](p *T, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": pointer is NOT nil"
+		defMsg := assertionMsg + ": pointer should be nil"
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -152,7 +152,7 @@ func INil(i any, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": interface is nil"
+		defMsg := assertionMsg + ": interface should be nil"
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -164,7 +164,7 @@ func INotNil(i any, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": interface is nil"
+		defMsg := assertionMsg + ": interface shouldn't be nil"
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -176,7 +176,7 @@ func SNil[T any](s []T, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": slice MUST be nil"
+		defMsg := assertionMsg + ": slice should be nil"
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -188,7 +188,7 @@ func SNotNil[T any](s []T, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": slice is nil"
+		defMsg := assertionMsg + ": slice shouldn't be nil"
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -200,7 +200,7 @@ func CNotNil[T any](c chan T, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": channel is nil"
+		defMsg := assertionMsg + ": channel shouldn't be nil"
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -212,7 +212,7 @@ func MNotNil[T comparable, U any](m map[T]U, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": map is nil"
+		defMsg := assertionMsg + ": map shouldn't be nil"
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -396,7 +396,7 @@ func NoError(err error, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": " + err.Error()
+		defMsg := "NoError:" + assertionMsg + ": " + err.Error()
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }
@@ -409,7 +409,7 @@ func Error(err error, a ...any) {
 		if DefaultAsserter().isUnitTesting() {
 			tester().Helper()
 		}
-		defMsg := assertionMsg + ": missing error"
+		defMsg := "Error:" + assertionMsg + ": missing error"
 		DefaultAsserter().reportAssertionFault(defMsg, a...)
 	}
 }

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -67,7 +67,7 @@ func ExampleNotNil() {
 	var b *byte
 	err := sample(b)
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:64 ExampleNotNil.func1 assertion violation: pointer shouldn't be nil
+	// Output: sample: assert_test.go:64 ExampleNotNil.func1(): assertion violation: pointer shouldn't be nil
 }
 
 func ExampleMNotNil() {
@@ -80,7 +80,7 @@ func ExampleMNotNil() {
 	var b map[string]byte
 	err := sample(b)
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:77 ExampleMNotNil.func1 assertion violation: map shouldn't be nil
+	// Output: sample: assert_test.go:77 ExampleMNotNil.func1(): assertion violation: map shouldn't be nil
 }
 
 func ExampleCNotNil() {
@@ -93,7 +93,7 @@ func ExampleCNotNil() {
 	var c chan byte
 	err := sample(c)
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:90 ExampleCNotNil.func1 assertion violation: channel shouldn't be nil
+	// Output: sample: assert_test.go:90 ExampleCNotNil.func1(): assertion violation: channel shouldn't be nil
 }
 
 func ExampleSNotNil() {
@@ -106,7 +106,7 @@ func ExampleSNotNil() {
 	var b []byte
 	err := sample(b)
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:103 ExampleSNotNil.func1 assertion violation: slice shouldn't be nil
+	// Output: sample: assert_test.go:103 ExampleSNotNil.func1(): assertion violation: slice shouldn't be nil
 }
 
 func ExampleEqual() {
@@ -118,7 +118,7 @@ func ExampleEqual() {
 	}
 	err := sample([]byte{1, 2})
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:116 ExampleEqual.func1 assertion violation: got 2, want 3
+	// Output: sample: assert_test.go:116 ExampleEqual.func1(): assertion violation: got 2, want 3
 }
 
 func ExampleSLen() {
@@ -130,7 +130,7 @@ func ExampleSLen() {
 	}
 	err := sample([]byte{1, 2})
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:128 ExampleSLen.func1 assertion violation: got 2, want 3
+	// Output: sample: assert_test.go:128 ExampleSLen.func1(): assertion violation: got 2, want 3
 }
 
 func ExampleAsserter_Lenf() {
@@ -183,7 +183,7 @@ func ExampleSNotEmpty() {
 	}
 	err := sample([]byte{})
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:181 ExampleSNotEmpty.func1 assertion violation: slice shouldn't be empty
+	// Output: sample: assert_test.go:181 ExampleSNotEmpty.func1(): assertion violation: slice shouldn't be empty
 }
 
 func ExampleNotEmpty() {
@@ -196,7 +196,7 @@ func ExampleNotEmpty() {
 	}
 	err := sample("")
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:194 ExampleNotEmpty.func1 assertion violation: string shouldn't be empty
+	// Output: sample: assert_test.go:194 ExampleNotEmpty.func1(): assertion violation: string shouldn't be empty
 }
 
 func ExampleMKeyExists() {
@@ -213,7 +213,7 @@ func ExampleMKeyExists() {
 	}
 	err := sample("2")
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:211 ExampleMKeyExists.func1 assertion violation: key '2' doesn't exist
+	// Output: sample: assert_test.go:211 ExampleMKeyExists.func1(): assertion violation: key '2' doesn't exist
 }
 
 func ExampleZero() {
@@ -226,7 +226,7 @@ func ExampleZero() {
 	var b int8 = 1 // we want sample to assert the violation.
 	err := sample(b)
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:223 ExampleZero.func1 assertion violation: value isn't zero
+	// Output: sample: assert_test.go:223 ExampleZero.func1(): assertion violation: got 1, want (== 0)
 }
 
 // ifPanicZero in needed that we have argument here! It's like a macro for

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -67,7 +67,7 @@ func ExampleNotNil() {
 	var b *byte
 	err := sample(b)
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:64 ExampleNotNil.func1 assertion violation: pointer is nil
+	// Output: sample: assert_test.go:64 ExampleNotNil.func1 assertion violation: pointer shouldn't be nil
 }
 
 func ExampleMNotNil() {
@@ -80,7 +80,7 @@ func ExampleMNotNil() {
 	var b map[string]byte
 	err := sample(b)
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:77 ExampleMNotNil.func1 assertion violation: map is nil
+	// Output: sample: assert_test.go:77 ExampleMNotNil.func1 assertion violation: map shouldn't be nil
 }
 
 func ExampleCNotNil() {
@@ -93,7 +93,7 @@ func ExampleCNotNil() {
 	var c chan byte
 	err := sample(c)
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:90 ExampleCNotNil.func1 assertion violation: channel is nil
+	// Output: sample: assert_test.go:90 ExampleCNotNil.func1 assertion violation: channel shouldn't be nil
 }
 
 func ExampleSNotNil() {
@@ -106,7 +106,7 @@ func ExampleSNotNil() {
 	var b []byte
 	err := sample(b)
 	fmt.Printf("%v", err)
-	// Output: sample: assert_test.go:103 ExampleSNotNil.func1 assertion violation: slice is nil
+	// Output: sample: assert_test.go:103 ExampleSNotNil.func1 assertion violation: slice shouldn't be nil
 }
 
 func ExampleEqual() {

--- a/assert/asserter.go
+++ b/assert/asserter.go
@@ -197,12 +197,12 @@ func (asserter Asserter) reportPanic(s string) {
 var longFmtStr = `
 --------------------------------
 Assertion Fault at:
-%s:%d %s
+%s:%d %s():
 %s
 --------------------------------
 `
 
-var shortFmtStr = `%s:%d %s %s`
+var shortFmtStr = `%s:%d %s(): %s`
 
 func (asserter Asserter) callerInfo(msg string) (info string) {
 	ourFmtStr := shortFmtStr

--- a/doc.go
+++ b/doc.go
@@ -68,11 +68,18 @@ the try package documentation for more information about the error checks.
 # Automatic Stack Tracing
 
 err2 offers optional stack tracing. And yes, it's fully automatic. Just set the
-tracers to the stream you want traces to be written:
+tracers at the beginning your app, e.g. main function, to the stream you want
+traces to be written:
 
 	err2.SetErrorTracer(os.Stderr) // write error stack trace to stderr
 	 or
 	err2.SetPanicTracer(log.Writer()) // panic stack trace to std logger
+
+Note. Since err2.Catch's default mode is to catch panics, the panic tracer's
+default values is os.Stderr. The default error tracer is nil.
+
+	err2.SetPanicTracer(os.Stderr) // panic stack tracer's default is stderr
+	err2.SetErrorTracer(nil) // error stack tracer's default is nil
 
 # Error handling
 

--- a/err2.go
+++ b/err2.go
@@ -26,7 +26,7 @@ var (
 	ErrRecoverable    = errors.New("recoverable")
 )
 
-// Handle is the general purpose error handling test. What makes it so
+// Handle is the general purpose error handling function. What makes it so
 // convenient is its ability to handle all error handling cases: a) just
 // return the error value to caller, b) annotate the error value, or c) execute
 // real error handling like cleanup and releasing resources. There is no

--- a/err2.go
+++ b/err2.go
@@ -26,7 +26,7 @@ var (
 	ErrRecoverable    = errors.New("recoverable")
 )
 
-// Handle is the general purpose error handling helper. What makes it so
+// Handle is the general purpose error handling test. What makes it so
 // convenient is its ability to handle all error handling cases: a) just
 // return the error value to caller, b) annotate the error value, or c) execute
 // real error handling like cleanup and releasing resources. There is no

--- a/err2.go
+++ b/err2.go
@@ -8,21 +8,23 @@ import (
 	"github.com/lainio/err2/internal/handler"
 )
 
-// nolint
 var (
-	// NotFound is similar *no-error* like io.EOF for those who really want to
+	// ErrNotFound is similar *no-error* like io.EOF for those who really want to
 	// use error return values to transport non errors. It's far better to have
 	// discriminated unions as errors for function calls. But if you insist the
 	// related helpers are in they try package: try.IsNotFound(), ... These
 	// 'global' errors and their helper functions in try package are for
 	// experimenting now.
-	NotFound  = errors.New("not found")
-	NotExist  = errors.New("not exist")
-	Exist     = errors.New("already exist")
-	NotAccess = errors.New("permission denied")
+	ErrNotFound     = errors.New("not found")
+	ErrNotExist     = errors.New("not exist")
+	ErrAlreadyExist = errors.New("already exist")
+	ErrNotAccess    = errors.New("permission denied")
 
-	NotRecoverable = errors.New("cannot recover")
-	Recoverable    = errors.New("recoverable")
+	// Since Go 1.20 wraps multiple errors same time, i.e. wrapped errors
+	// aren't list anymore but tree. This allows mark multiple semantics to
+	// same error. These error are mainly for that purpose.
+	ErrNotRecoverable = errors.New("cannot recover")
+	ErrRecoverable    = errors.New("recoverable")
 )
 
 // Handle is the general purpose error handling helper. What makes it so
@@ -178,7 +180,8 @@ func CatchTrace(errorHandler func(err error)) {
 // return value, it's called only if you want to non-local control structure for
 // error handling, i.e. your current function doesn't have error return value.
 // NOTE, Throwf is rarely needed. We suggest to use error return values instead.
-// Throwf is offered for deep recursive algorithms to help readability.
+// Throwf is offered for deep recursive algorithms to help readability and
+// preformance (see bechmarks) in those cases.
 //
 //	func yourFn() (res any) {
 //	     ...

--- a/err2_test.go
+++ b/err2_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/lainio/err2"
-	"github.com/lainio/err2/internal/helper"
+	"github.com/lainio/err2/internal/test"
 	"github.com/lainio/err2/try"
 )
 
@@ -100,7 +100,7 @@ func TestPanickingCatchAll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				helper.Require(t, recover() == nil, "panics should NOT carry on")
+				test.Require(t, recover() == nil, "panics should NOT carry on")
 			}()
 			tt.args.f()
 		})
@@ -141,7 +141,7 @@ func TestPanickingCarryOn_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				helper.Require(t, recover() != nil, "panics should went thru when not our errors")
+				test.Require(t, recover() != nil, "panics should went thru when not our errors")
 			}()
 			tt.args.f()
 		})
@@ -245,12 +245,12 @@ func TestPanicking_Handle(t *testing.T) {
 			defer func() {
 				r := recover()
 				if tt.wants == nil {
-					helper.Require(t, r != nil, "wants err, then panic")
+					test.Require(t, r != nil, "wants err, then panic")
 				}
 			}()
 			err := tt.args.f()
 			if err != nil {
-				helper.Requiref(t, err == myErr, "got %p, want %p", err, myErr)
+				test.Requiref(t, err == myErr, "got %p, want %p", err, myErr)
 			}
 		})
 	}
@@ -288,7 +288,7 @@ func TestPanicking_Catch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				helper.Require(t, recover() == nil, "panics should NOT carry on")
+				test.Require(t, recover() == nil, "panics should NOT carry on")
 			}()
 			tt.args.f()
 		})
@@ -326,11 +326,11 @@ func TestCatch_Panic(t *testing.T) {
 
 func TestSetErrorTracer(t *testing.T) {
 	w := err2.ErrorTracer()
-	helper.Require(t, w == nil, "error tracer should be nil")
+	test.Require(t, w == nil, "error tracer should be nil")
 	var w1 io.Writer
 	err2.SetErrorTracer(w1)
 	w = err2.ErrorTracer()
-	helper.Require(t, w == nil, "error tracer should be nil")
+	test.Require(t, w == nil, "error tracer should be nil")
 }
 
 func ExampleHandle() {

--- a/err2_test.go
+++ b/err2_test.go
@@ -361,7 +361,7 @@ func ExampleHandle_errReturn() {
 	// Output: our error
 }
 
-func ExampleReturnf_empty() {
+func ExampleHandle_empty() {
 	annotated := func() (err error) {
 		defer err2.Handle(&err, "annotated")
 		try.To1(throw())
@@ -409,7 +409,7 @@ func ExampleThrowf() {
 	// Output: annotated: err2: helper failed at: 78
 }
 
-func ExampleReturnf_deferStack() {
+func ExampleHandle_deferStack() {
 	annotated := func() (err error) {
 		defer err2.Handle(&err, "annotated 2nd")
 		defer err2.Handle(&err, "annotated 1st")

--- a/err2_test.go
+++ b/err2_test.go
@@ -23,7 +23,7 @@ func noErr() error {
 	return nil
 }
 
-func TestTry_noError(t *testing.T) {
+func TestTry_noError(_ *testing.T) {
 	try.To1(noThrow())
 	try.To2(twoStrNoThrow())
 	try.To2(intStrNoThrow())

--- a/err2_test.go
+++ b/err2_test.go
@@ -3,6 +3,7 @@ package err2_test
 import (
 	"fmt"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/lainio/err2"
@@ -579,3 +580,16 @@ func BenchmarkRecursionWithTryAndDefer(b *testing.B) {
 		_, _ = recursion(100)
 	}
 }
+
+func TestMain(m *testing.M) {
+	setUp()
+	code := m.Run()
+	tearDown()
+	os.Exit(code)
+}
+
+func setUp() {
+	err2.SetPanicTracer(nil)
+}
+
+func tearDown() {}

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/lainio/err2/internal/helper"
+	"github.com/lainio/err2/internal/x"
 )
 
 type StackInfo struct {
@@ -103,7 +103,7 @@ func funcName(r io.Reader, si StackInfo) (n string, ln int, ok bool) {
 
 			// we are interested the line before (2 x si.Level) the
 			// anchorLine, AND we want to calc this only once
-			reachAnchor = helper.Whom(reachAnchor, true,
+			reachAnchor = x.Whom(reachAnchor, true,
 				i == (anchorLine-2*si.Level))
 
 			if reachAnchor && i%2 == 0 && notOurFunction(line) {

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lainio/err2/internal/helper"
+	"github.com/lainio/err2/internal/test"
 )
 
 func TestFullName(t *testing.T) {
@@ -26,7 +26,7 @@ func TestFullName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			helper.Requiref(t, tt.retval == tt.fullName(), "must be equal: %s",
+			test.Requiref(t, tt.retval == tt.fullName(), "must be equal: %s",
 				tt.retval)
 		})
 	}
@@ -75,7 +75,7 @@ func TestIsAnchor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			helper.Require(t, tt.retval == tt.isAnchor(tt.input), "equal")
+			test.Require(t, tt.retval == tt.isAnchor(tt.input), "equal")
 		})
 	}
 }
@@ -117,7 +117,7 @@ func TestIsFuncAnchor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			helper.Require(t, tt.retval == tt.isFuncAnchor(tt.input), "equal")
+			test.Require(t, tt.retval == tt.isFuncAnchor(tt.input), "equal")
 		})
 	}
 }
@@ -135,7 +135,7 @@ func TestFnLNro(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			output := fnLNro(tt.input)
-			helper.Require(t, output == tt.output, output)
+			test.Require(t, output == tt.output, output)
 		})
 	}
 }
@@ -164,7 +164,7 @@ func TestFnName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			output := fnName(tt.input)
-			helper.Require(t, output == tt.output, output)
+			test.Require(t, output == tt.output, output)
 		})
 	}
 }
@@ -187,7 +187,7 @@ func TestStackPrint_noLimits(t *testing.T) {
 				FuncName:    "",
 				Level:       0,
 			})
-			helper.Require(t, tt.input == w.String(), "")
+			test.Require(t, tt.input == w.String(), "")
 		})
 	}
 }
@@ -215,7 +215,7 @@ func TestCalcAnchor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := strings.NewReader(tt.input)
 			anchor := calcAnchor(r, tt.StackInfo)
-			helper.Require(t, tt.anchor == anchor, "equal")
+			test.Require(t, tt.anchor == anchor, "equal")
 		})
 	}
 }
@@ -248,8 +248,8 @@ func TestStackPrint_limit(t *testing.T) {
 			})
 			ins := strings.Split(tt.input, "\n")
 			outs := strings.Split(w.String(), "\n")
-			helper.Require(t, len(ins) > len(outs), "input length should be greater")
-			helper.Require(t, tt.output == w.String(), "not equal")
+			test.Require(t, len(ins) > len(outs), "input length should be greater")
+			test.Require(t, tt.output == w.String(), "not equal")
 		})
 	}
 }
@@ -278,9 +278,9 @@ func TestFuncName(t *testing.T) {
 				FuncName:    tt.FuncName,
 				Level:       tt.Level,
 			})
-			helper.Require(t, ok, "not found")
-			helper.Requiref(t, tt.output == name, "not equal %v", name)
-			helper.Requiref(t, ln == tt.outln, "ln must be equal %d == %d", ln, tt.outln)
+			test.Require(t, ok, "not found")
+			test.Requiref(t, tt.output == name, "not equal %v", name)
+			test.Requiref(t, ln == tt.outln, "ln must be equal %d == %d", ln, tt.outln)
 		})
 	}
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -50,7 +50,7 @@ const (
 	wrapError = ": %w"
 )
 
-func PanicNoop(v any) {}
+func PanicNoop(_ any) {}
 func NilNoop()        {}
 
 // func ErrorNoop(err error) {}

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/lainio/err2/internal/handler"
-	"github.com/lainio/err2/internal/helper"
+	"github.com/lainio/err2/internal/test"
 )
 
 func TestProcess(t *testing.T) {
@@ -116,17 +116,17 @@ func TestProcess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler.Process(&tt.args.Info)
 
-			helper.Requiref(t, tt.want.panicCalled == panicHandlerCalled,
+			test.Requiref(t, tt.want.panicCalled == panicHandlerCalled,
 				"panicHandler: got = %v, want = %v",
 				panicHandlerCalled, tt.want.panicCalled)
-			helper.Requiref(t, tt.want.errorCalled == errorHandlerCalled,
+			test.Requiref(t, tt.want.errorCalled == errorHandlerCalled,
 				"errorHandler: got = %v, want = %v",
 				errorHandlerCalled, tt.want.errorCalled)
-			helper.Requiref(t, tt.want.nilCalled == nilHandlerCalled,
+			test.Requiref(t, tt.want.nilCalled == nilHandlerCalled,
 				"nilHandler: got = %v, want = %v",
 				nilHandlerCalled, tt.want.nilCalled)
 
-			helper.Requiref(t, tt.want.errStr == myErrVal.Error(),
+			test.Requiref(t, tt.want.errStr == myErrVal.Error(),
 				"got: %v, want: %v", myErrVal.Error(), tt.want.errStr)
 
 			resetCalled()
@@ -151,19 +151,19 @@ func TestPreProcess_debug(t *testing.T) {
 	// and that's what error stack tracing is all about
 	Handle()
 
-	helper.Requiref(t, false == panicHandlerCalled,
+	test.Requiref(t, false == panicHandlerCalled,
 		"panicHandler: got = %v, want = %v",
 		panicHandlerCalled, false)
-	helper.Requiref(t, false == errorHandlerCalled,
+	test.Requiref(t, false == errorHandlerCalled,
 		"errorHandler: got = %v, want = %v",
 		errorHandlerCalled, false)
-	helper.Requiref(t, false == nilHandlerCalled,
+	test.Requiref(t, false == nilHandlerCalled,
 		"nilHandler: got = %v, want = %v",
 		nilHandlerCalled, true)
 
 	// See the name of this test function. Decamel it + error
 	const want = "testing t runner: error"
-	helper.Requiref(t, want == myErrVal.Error(),
+	test.Requiref(t, want == myErrVal.Error(),
 		"got: %v, want: %v", myErrVal.Error(), want)
 
 	resetCalled()
@@ -241,17 +241,17 @@ func TestPreProcess(t *testing.T) {
 			if len(tt.args.a) > 0 {
 				handler.PreProcess(&tt.args.Info, tt.args.a...)
 
-				helper.Requiref(t, tt.want.panicCalled == panicHandlerCalled,
+				test.Requiref(t, tt.want.panicCalled == panicHandlerCalled,
 					"panicHandler: got = %v, want = %v",
 					panicHandlerCalled, tt.want.panicCalled)
-				helper.Requiref(t, tt.want.errorCalled == errorHandlerCalled,
+				test.Requiref(t, tt.want.errorCalled == errorHandlerCalled,
 					"errorHandler: got = %v, want = %v",
 					errorHandlerCalled, tt.want.errorCalled)
-				helper.Requiref(t, tt.want.nilCalled == nilHandlerCalled,
+				test.Requiref(t, tt.want.nilCalled == nilHandlerCalled,
 					"nilHandler: got = %v, want = %v",
 					nilHandlerCalled, tt.want.nilCalled)
 
-				helper.Requiref(t, tt.want.errStr == myErrVal.Error(),
+				test.Requiref(t, tt.want.errStr == myErrVal.Error(),
 					"got: %v, want: %v", myErrVal.Error(), tt.want.errStr)
 
 				resetCalled()

--- a/internal/str/str.go
+++ b/internal/str/str.go
@@ -43,10 +43,9 @@ func Decamel(s string) string {
 		if toSpace {
 			if prevSkipped {
 				continue
-			} else {
-				v = ' '
-				prevSkipped = true
 			}
+			v = ' '
+			prevSkipped = true
 		} else {
 			isUpper = unicode.IsUpper(v)
 			if isUpper {

--- a/internal/str/str_test.go
+++ b/internal/str/str_test.go
@@ -3,8 +3,8 @@ package str_test
 import (
 	"testing"
 
-	"github.com/lainio/err2/internal/helper"
 	"github.com/lainio/err2/internal/str"
+	"github.com/lainio/err2/internal/test"
 )
 
 const (
@@ -47,7 +47,7 @@ func TestDecamel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := str.Decamel(tt.args.s)
-			helper.Requiref(t, got == tt.want, "got: %v, want: %v", got, tt.want)
+			test.Requiref(t, got == tt.want, "got: %v, want: %v", got, tt.want)
 		})
 	}
 }

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -1,4 +1,4 @@
-package helper
+package test
 
 import "testing"
 
@@ -16,13 +16,4 @@ func Requiref(tb testing.TB, condition bool, format string, v ...interface{}) {
 	if !condition {
 		tb.Fatalf(format, v...)
 	}
-}
-
-// Whom is exactly same as C/C++ ternary operator. In Go it's implemented with
-// generics.
-func Whom[T any](b bool, yes, no T) T {
-	if b {
-		return yes
-	}
-	return no
 }

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -3,6 +3,7 @@ package tracer
 
 import (
 	"io"
+	"os"
 	"sync/atomic"
 )
 
@@ -21,7 +22,8 @@ var (
 
 func init() {
 	Error.SetTracer(nil)
-	Panic.SetTracer(nil)
+	// Because we stop panics as default, we need to output as default
+	Panic.SetTracer(os.Stderr)
 }
 
 func (v *value) Tracer() io.Writer {

--- a/internal/x/x.go
+++ b/internal/x/x.go
@@ -1,0 +1,10 @@
+package x
+
+// Whom is exactly same as C/C++ ternary operator. In Go it's implemented with
+// generics.
+func Whom[T any](b bool, yes, no T) T {
+	if b {
+		return yes
+	}
+	return no
+}

--- a/samples/main.go
+++ b/samples/main.go
@@ -22,10 +22,6 @@ import (
 func CopyFile(src, dst string) (err error) {
 	defer err2.Handle(&err) // automatic error message: see err2.Formatter
 
-	// the next line is example how to enrich error message when starting with
-	// automatic.
-	//defer err2.Handle(&err, "(%v, %v)", src, dst)
-
 	// You can comment above handler line(s) out an see what happens.
 	// You'll learn that call stacks are for every function level 'catch'
 	// statement like defer err2.Handle() is.
@@ -51,19 +47,26 @@ func CopyFile(src, dst string) (err error) {
 func callRecur(d int) (err error) {
 	defer err2.Handle(&err)
 
-	return recur(d)
+	return doRecur(d)
 }
 
-func recur(d int) (err error) {
+func doRecur(d int) (err error) {
 	d--
 	if d >= 0 {
+		if d == 0 {
+			assert.NotImplemented()
+		}
 		fmt.Println(10 / d)
-		return recur(d)
+		return doRecur(d)
 	}
 	return fmt.Errorf("root error")
 }
 
 func main() {
+	// if asserts are treated as panics instead of errors you get stack trace.
+	// you can try that by taking next line out of the comment:
+	//assert.SetDefaultAsserter(assert.AsserterFormattedCallerInfo|assert.AsserterDebug)
+
 	// To see how automatic stack tracing works.
 	//err2.SetErrorTracer(os.Stderr)
 	//err2.SetPanicTracer(os.Stderr) // this is the default

--- a/samples/main.go
+++ b/samples/main.go
@@ -53,9 +53,9 @@ func callRecur(d int) (err error) {
 func doRecur(d int) (err error) {
 	d--
 	if d >= 0 {
-		if d == 0 {
-			assert.NotImplemented()
-		}
+		// keep below to show how asserts work
+		assert.NotZero(d)
+		// comment out above assert-statement to simulate runtime-error
 		fmt.Println(10 / d)
 		return doRecur(d)
 	}
@@ -63,9 +63,14 @@ func doRecur(d int) (err error) {
 }
 
 func main() {
+	// keep here that you can play without changing imports
+	assert.That(true)
+
 	// if asserts are treated as panics instead of errors you get stack trace.
 	// you can try that by taking next line out of the comment:
 	//assert.SetDefaultAsserter(assert.AsserterFormattedCallerInfo|assert.AsserterDebug)
+	// same thing but one line assert msg
+	//assert.SetDefaultAsserter(assert.AsserterCallerInfo|assert.AsserterDebug)
 
 	// To see how automatic stack tracing works.
 	//err2.SetErrorTracer(os.Stderr)
@@ -96,7 +101,6 @@ func doMain() (err error) {
 	// how err2 works. Especially interesting is automatic stack tracing.
 	//
 	// source file exist, but destination not in high probability
-	//try.To(callRecur(1))
 	try.To(CopyFile("main.go", "/notfound/path/file.bak"))
 	//
 	// both source and destination doesn't exist
@@ -104,6 +108,10 @@ func doMain() (err error) {
 	//
 	// first argument is empty
 	//try.To(CopyFile("main.go", ""))
+
+	// Next fn demonstrates how error and panic traces work, comment out all
+	// above CopyFile calls to play withit:
+	try.To(callRecur(1))
 
 	println("=== you cannot see this ===")
 	return nil

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,11 +9,19 @@ successfully from type variables (see below) to Go generics API.
 This readme will guide you to use auto-migration scripts when ever we deprecate
 functions or make something obsolete.
 
-### `err2.Return(f/w)` will obsolete in v 0.9.0
+### `err2.NotFound`, `err2.NotExist` and other sentinels are renamed in v0.9.0
+
+Their names follow Go idiom even the `err` part is two times here:
+`err2.ErrNotFound`.
+
+Please follow the same steps presented for v0.8.10 below to automatically
+refactor all references to these error values in your repos.
+
+### `err2.Return(f/w)` will obsolete in v0.9.0
 
 Please follow the same steps as the next chapter.
 
-### `err2.Annotate` and `err2.StackTraceWriter` are obsolete in v 0.8.10
+### `err2.Annotate` and `err2.StackTraceWriter` are obsolete in v0.8.10
 
 Please follow these guides to automatically replace all obsolete `err2.Annotate`
 functions and `err2.StackTraceWriter` variable set with proper API:

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -155,6 +155,15 @@ replace_annotate() {
 	"$location"/replace-perl.sh 'err2\.(Annotatew\()(.*)(, )(.*)(\)\n)' 'err2.Returnw(\4\3\2\5'
 }
 
+replace_err_values() {
+	"$location"/replace.sh 'err2\.NotFound' 'err2.ErrNotFound'
+	"$location"/replace.sh 'err2\.NotExist' 'err2.ErrNotExist'
+	"$location"/replace.sh 'err2\.AlreadyExist' 'err2.ErrAlreadyExist'
+	"$location"/replace.sh 'err2\.NotAccess' 'err2.ErrNotAccess'
+	"$location"/replace.sh 'err2\.NotRecoverable' 'err2.ErrNotRecoverable'
+	"$location"/replace.sh 'err2\.Recoverable' 'err2.ErrRecoverable'
+}
+
 replace_easy1() {
 	vlog "Replacing err2.Check, err2.FilterTry, err2.TryEOF, and type vars"
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -407,12 +407,12 @@ check_if_stop_for_simplex() {
 
 todo() {
 	dlog "Searching err2 references out of catchers"
-	ag -l 'err2\.(Check|Try|Filter)'
+	ag -l 'err2\.(Check|Try|Filter|CatchAll|CatchTrace|Annotate|Return)'
 }
 
 todo_show() {
 	dlog "Searching err2 references out of catchers"
-	ag 'err2\.(Check|Try|Filter)'
+	ag 'err2\.(Check|Try|Filter|CatchAll|CatchTrace|Annotate|Return)'
 }
 
 todo2() {

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -60,9 +60,9 @@ check_prerequisites() {
 	fi
 
 	local go_version=$(go mod edit -json | jq -r '."Go"')
-	if [[ $go_version < 1.18 ]]; then
+	if [[ $go_version < 1.19 ]]; then
 		echo "ERROR:  Go version number ($go_version) is too low" >&2
-		echo "Sample: go mod edit -go=1.18 # sets the minimal version" >&2
+		echo "Sample: go mod edit -go=1.19 # sets the minimal version" >&2
 		exit 1
 	fi
 

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -72,6 +72,7 @@ commit "commit deps"
 echo "====== basic err2 refactoring ===="
 echo "processing..."
 
+replace_err_values
 replace_catch
 replace_tracers
 replace_defasserter

--- a/snippets/go.json
+++ b/snippets/go.json
@@ -23,7 +23,27 @@
 		"assert.That()": {
 			"prefix": "asth",
 			"body": "assert.That(${1:bool}$2)",
-			"description": "Snippet for pushing current tester"
+			"description": "Snippet for generic That assert"
+		},
+		"assert.Equal()": {
+			"prefix": "aseq",
+			"body": "assert.Equal(${1:got}, ${2:want}$3)",
+			"description": "Snippet for Equal assert"
+		},
+		"assert.NotImplemented()": {
+			"prefix": "asni",
+			"body": "assert.NotImplemented($1)",
+			"description": "Snippet for not implemented assert"
+		},
+		"assert.NotNil()": {
+			"prefix": "asnn",
+			"body": "assert.NotNil(${1:ptr}$2)",
+			"description": "Snippet for NotNil assert"
+		},
+		"assert.INotNil()": {
+			"prefix": "asinn",
+			"body": "assert.INotNil(${1:interface}$2)",
+			"description": "Snippet for INotNil assert"
 		}
 	}
 }

--- a/tracer.go
+++ b/tracer.go
@@ -7,21 +7,21 @@ import (
 )
 
 // ErrorTracer returns current io.Writer for automatic error stack tracing.
+// The default value is nil.
 func ErrorTracer() io.Writer {
 	return tracer.Error.Tracer()
 }
 
 // PanicTracer returns current io.Writer for automatic panic stack tracing. Note
 // that runtime.Error types which are transported by panics are controlled by
-// this.
+// this. The default value is os.Stderr.
 func PanicTracer() io.Writer {
 	return tracer.Panic.Tracer()
 }
 
-// SetErrorTracer sets a io.Writer for automatic error stack tracing. Note
-// that runtime.Error types which are transported by panics are controlled by
-// this. Note also that the current function is capable to print error stack
-// trace when the function has at least one deferred error handler, e.g:
+// SetErrorTracer sets a io.Writer for automatic error stack tracing. The err2
+// default is nil. Note that the current function is capable to print error
+// stack trace when the function has at least one deferred error handler, e.g:
 //
 //	func CopyFile(src, dst string) (err error) {
 //	     defer err2.Handle(&err) // <- error trace print decision is done here
@@ -29,10 +29,11 @@ func SetErrorTracer(w io.Writer) {
 	tracer.Error.SetTracer(w)
 }
 
-// SetPanicTracer sets a io.Writer for automatic panic stack tracing. Note
-// that runtime.Error types which are transported by panics are controlled by
-// this. Note also that the current function is capable to print panic stack
-// trace when the function has at least one deferred error handler, e.g:
+// SetPanicTracer sets a io.Writer for automatic panic stack tracing. The err2
+// default is os.Stderr. Note that runtime.Error types which are transported by
+// panics are controlled by this. Note also that the current function is capable
+// to print panic stack trace when the function has at least one deferred error
+// handler, e.g:
 //
 //	func CopyFile(src, dst string) (err error) {
 //	     defer err2.Handle(&err) // <- error trace print decision is done here

--- a/try/copy_test.go
+++ b/try/copy_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/lainio/err2/internal/helper"
+	"github.com/lainio/err2/internal/test"
 	"github.com/lainio/err2/try"
 )
 
@@ -15,8 +15,8 @@ const dataFile = "./try.go"
 
 func Benchmark_CopyBufferStd(b *testing.B) {
 	all, err := os.ReadFile(dataFile)
-	helper.Requiref(b, err == nil, "error: %v", err)
-	helper.Require(b, all != nil)
+	test.Requiref(b, err == nil, "error: %v", err)
+	test.Require(b, all != nil)
 
 	buf := make([]byte, 4)
 	dst := bufio.NewWriter(bytes.NewBuffer(make([]byte, 0, len(all))))
@@ -28,8 +28,8 @@ func Benchmark_CopyBufferStd(b *testing.B) {
 
 func Benchmark_CopyBufferOur(b *testing.B) {
 	all, err := os.ReadFile(dataFile)
-	helper.Requiref(b, err == nil, "error: %v", err)
-	helper.Require(b, all != nil)
+	test.Requiref(b, err == nil, "error: %v", err)
+	test.Require(b, all != nil)
 
 	tmp := make([]byte, 4)
 	dst := bufio.NewWriter(bytes.NewBuffer(make([]byte, 0, len(all))))

--- a/try/copy_test.go
+++ b/try/copy_test.go
@@ -1,4 +1,4 @@
-package err2_test
+package try_test
 
 import (
 	"bufio"
@@ -11,8 +11,10 @@ import (
 	"github.com/lainio/err2/try"
 )
 
+const dataFile = "./try.go"
+
 func Benchmark_CopyBufferStd(b *testing.B) {
-	all, err := os.ReadFile("./err2_test.go")
+	all, err := os.ReadFile(dataFile)
 	helper.Requiref(b, err == nil, "error: %v", err)
 	helper.Require(b, all != nil)
 
@@ -25,7 +27,7 @@ func Benchmark_CopyBufferStd(b *testing.B) {
 }
 
 func Benchmark_CopyBufferOur(b *testing.B) {
-	all, err := os.ReadFile("err2_test.go")
+	all, err := os.ReadFile(dataFile)
 	helper.Requiref(b, err == nil, "error: %v", err)
 	helper.Require(b, all != nil)
 

--- a/try/notfound_test.go
+++ b/try/notfound_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lainio/err2/try"
 )
 
-func FindObject(key int) (val string, err error) {
+func FindObject(_ int) (val string, err error) {
 	defer err2.Handle(&err)
 
 	// both of the following lines can be used to transport err2.NotFound

--- a/try/notfound_test.go
+++ b/try/notfound_test.go
@@ -13,8 +13,8 @@ func FindObject(key int) (val string, err error) {
 
 	// both of the following lines can be used to transport err2.NotFound
 	// you can try by outcommenting err2.Throwf
-	//err2.Throwf("panic transport: %w", err2.NotFound)
-	return "", err2.NotFound
+	//err2.Throwf("panic transport: %w", err2.ErrNotFound)
+	return "", err2.ErrNotFound
 }
 
 func ExampleIsNotFound1() {

--- a/try/try.go
+++ b/try/try.go
@@ -124,7 +124,7 @@ func IsEOF(err error) bool {
 // there are no errors. The true tells that the err's chain includes
 // 'err2.NotFound'.
 func IsNotFound(err error) bool {
-	return Is(err, err2.NotFound)
+	return Is(err, err2.ErrNotFound)
 }
 
 // IsNotFound1 function performs a filtered error check for the given argument.
@@ -133,7 +133,7 @@ func IsNotFound(err error) bool {
 // there are no errors. The true tells that the err's chain includes
 // 'err2.NotFound'.
 func IsNotFound1[T any](v T, err error) (bool, T) {
-	isFilter := Is(err, err2.NotFound)
+	isFilter := Is(err, err2.ErrNotFound)
 	return isFilter, v
 }
 
@@ -143,15 +143,15 @@ func IsNotFound1[T any](v T, err error) (bool, T) {
 // there are no errors. The true tells that the err's chain includes
 // 'err2.NotExist'.
 func IsNotExist(err error) bool {
-	return Is(err, err2.NotExist)
+	return Is(err, err2.ErrNotExist)
 }
 
 // IsExist function performs a filtered error check for the given argument. It's
 // the same as To function, but it checks if the error matches the 'err2.Exist'
 // before throwing an error. The false return value tells that there are no
 // errors. The true tells that the err's chain includes 'err2.Exist'.
-func IsExist(err error) bool {
-	return Is(err, err2.Exist)
+func IsAlreadyExist(err error) bool {
+	return Is(err, err2.ErrAlreadyExist)
 }
 
 // IsNotAccess function performs a filtered error check for the given argument.
@@ -160,5 +160,23 @@ func IsExist(err error) bool {
 // there are no errors. The true tells that the err's chain includes
 // 'err2.NotAccess'.
 func IsNotAccess(err error) bool {
-	return Is(err, err2.NotAccess)
+	return Is(err, err2.ErrNotAccess)
+}
+
+// IsRecoverable function performs a filtered error check for the given argument.
+// It's the same as To function, but it checks if the error matches the
+// 'err2.ErrRecoverable' before throwing an error. The false return value tells that
+// there are no errors. The true tells that the err's chain includes
+// 'err2.ErrRecoverable'.
+func IsRecoverable(err error) bool {
+	return Is(err, err2.ErrRecoverable)
+}
+
+// IsNotRecoverable function performs a filtered error check for the given argument.
+// It's the same as To function, but it checks if the error matches the
+// 'err2.ErrNotRecoverable' before throwing an error. The false return value tells that
+// there are no errors. The true tells that the err's chain includes
+// 'err2.ErrNotRecoverable'.
+func IsNotRecoverable(err error) bool {
+	return Is(err, err2.ErrNotRecoverable)
 }


### PR DESCRIPTION
- move buffer copy bench to try/
- go 1.19 is now needed
- setting PanicTracer to os.Stderr as default
- coverage added to ignored
- coverage rule for makefile
- roadmap and next release
- err2 pkg documentation for tracers
- convention for error var names
- new the stuff to sample main.go
- new snipets
- notfound_test update for new err vars
- updated functions todos for latest versions of jobs
- support new err vars and new Is functions
- obsolete deprecated
- better default assertion messages
- readme fixes and better assert section
- gofmt and test updates for new assert default msg
- New assert -section
- refactor helper -> test & x pkgs
- go documentation mistake fixed
- linter fixes
- added TestMain to err2_test
- Readme formatting version history
- test badge and some release notes
- bug in NotImplemented: didn't used DefaultAsserter
- more control flows to test err2, assert pkgs and their default settings
- testing badges and their position
- better badges
- assert fmt msgs, NotZero added, tests updated
- more options to sample app playground
- more migration documentation for renamed sentinel errors
- sentinel error renaming migration scripts
- better assert pkg documentation in README
- new updates how assert pkg is shared for tests and runtime
- readme language and added blog post link
