### PR TITLE
v0 9 40

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,24 +5,39 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: latest
-          args: --timeout=5m
+    - uses: actions/checkout@v3
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: latest
+        args: --timeout=5m
   test:
+    strategy:
+      matrix:
+        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: setup go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: test
+      run: make test
+  test-cov:
     runs-on: ubuntu-latest
     steps:
-      - name: setup
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.19.x
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: test
-        run: make test_cov_out
-      - name: upload
-        uses: codecov/codecov-action@v2
-        with:
-          files: ./coverage.txt
+    - name: setup
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.19.x
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: test
+      run: make test_cov_out
+    - name: upload
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ coverage.*
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,22 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+- skip: true
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Cangelog
+## Changelog
 
 ### Version history
 

--- a/Makefile
+++ b/Makefile
@@ -58,46 +58,43 @@ tinline_handler:
 	$(GO) test -c -gcflags=-m=2 $(PKG_HANDLER) 2>&1 | ag 'inlin'
 
 bench:
-	$(GO) test -bench=. $(PKGS)
+	$(GO) test $(TEST_ARGS) -bench=. $(PKGS)
 
 bench_goid:
-	$(GO) test -bench='BenchmarkGoid' $(PKG_ASSERT)
+	$(GO) test $(TEST_ARGS) -bench='BenchmarkGoid' $(PKG_ASSERT)
 
 bench_reca:
-	$(GO) test -bench='BenchmarkRecursion.*' $(PKG_ERR2)
+	$(GO) test $(TEST_ARGS) -bench='BenchmarkRecursion.*' $(PKG_ERR2)
 
 bench_out:
-	$(GO) test -bench='BenchmarkTryOut_.*' $(PKG_ERR2)
+	$(GO) test $(TEST_ARGS) -bench='BenchmarkTryOut_.*' $(PKG_ERR2)
 
 bench_go:
-	$(GO) test -bench='BenchmarkTry_StringGenerics' $(PKG_ERR2)
-
-bench_arec:
-	$(GO) test -bench='BenchmarkRecursion.*' $(PKG_ERR2)
+	$(GO) test $(TEST_ARGS) -bench='BenchmarkTry_StringGenerics' $(PKG_ERR2)
 
 bench_that:
-	$(GO) test -bench='BenchmarkThat.*' $(PKG_ASSERT)
+	$(GO) test $(TEST_ARGS) -bench='BenchmarkThat.*' $(PKG_ASSERT)
 
 bench_copy:
-	$(GO) test -bench='Benchmark_CopyBuffer' $(PKG_TRY)
+	$(GO) test $(TEST_ARGS) -bench='Benchmark_CopyBuffer' $(PKG_TRY)
 
 bench_rece:
-	$(GO) test -bench='BenchmarkRecursionWithTryAnd_Empty_Defer' $(PKG_ERR2)
+	$(GO) test $(TEST_ARGS) -bench='BenchmarkRecursionWithTryAnd_Empty_Defer' $(PKG_ERR2)
 
 bench_rec:
-	$(GO) test -bench='BenchmarkRecursionWithOldErrorIfCheckAnd_Defer' $(PKG_ERR2)
+	$(GO) test $(TEST_ARGS) -bench='BenchmarkRecursionWithOldErrorIfCheckAnd_Defer' $(PKG_ERR2)
 
 bench_err2:
-	$(GO) test -bench=. $(PKG_ERR2)
+	$(GO) test $(TEST_ARGS) -bench=. $(PKG_ERR2)
 
 bench_assert:
-	$(GO) test -bench=. $(PKG_ASSERT)
+	$(GO) test $(TEST_ARGS) -bench=. $(PKG_ASSERT)
 
 bench_str:
-	$(GO) test -bench=. $(PKG_STR)
+	$(GO) test $(TEST_ARGS) -bench=. $(PKG_STR)
 
 bench_x:
-	$(GO) test -bench=. $(PKG_X)
+	$(GO) test $(TEST_ARGS) -bench=. $(PKG_X)
 
 vet: | test
 	$(GO) vet $(PKGS)

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ test_str:
 test_x:
 	$(GO) test $(TEST_ARGS) $(PKG_X)
 
+testv:
+	$(GO) test -v $(TEST_ARGS) $(PKGS)
+
 test:
 	$(GO) test $(TEST_ARGS) $(PKGS)
 

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,18 @@ testv:
 test:
 	$(GO) test $(TEST_ARGS) $(PKGS)
 
+inline_err2:
+	$(GO) test -c -gcflags=-m=2 $(PKG_ERR2) 2>&1 | ag 'inlin' 
+
+tinline_err2:
+	$(GO) test -c -gcflags=-m=2 $(PKG_ERR2) 2>&1 | ag 'inlin' | ag 'err2_test'
+
+inline_handler:
+	$(GO) test -c -gcflags=-m=2 $(PKG_HANDLER) 2>&1 | ag 'inlin' 
+
+tinline_handler:
+	$(GO) test -c -gcflags=-m=2 $(PKG_HANDLER) 2>&1 | ag 'inlin'
+
 bench:
 	$(GO) test -bench=. $(PKGS)
 
@@ -68,6 +80,9 @@ bench_that:
 
 bench_copy:
 	$(GO) test -bench='Benchmark_CopyBuffer' $(PKG_TRY)
+
+bench_rece:
+	$(GO) test -bench='BenchmarkRecursionWithTryAnd_Empty_Defer' $(PKG_ERR2)
 
 bench_rec:
 	$(GO) test -bench='BenchmarkRecursionWithOldErrorIfCheckAnd_Defer' $(PKG_ERR2)

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ PKG_ERR2 := github.com/lainio/err2
 PKG_ASSERT := github.com/lainio/err2/assert
 PKG_TRY := github.com/lainio/err2/try
 PKG_DEBUG := github.com/lainio/err2/internal/debug
+PKG_HANDLER := github.com/lainio/err2/internal/handler
 PKG_STR := github.com/lainio/err2/internal/str
 PKG_X := github.com/lainio/err2/internal/x
-PKGS := $(PKG_ERR2) $(PKG_ASSERT) $(PKG_TRY) $(PKG_DEBUG) $(PKG_STR) $(PKG_X)
+PKGS := $(PKG_ERR2) $(PKG_ASSERT) $(PKG_TRY) $(PKG_DEBUG) $(PKG_HANDLER) $(PKG_STR) $(PKG_X)
 
 SRCDIRS := $(shell go list -f '{{.Dir}}' $(PKGS))
 
@@ -28,6 +29,9 @@ test_try:
 
 test_debug:
 	$(GO) test $(TEST_ARGS) $(PKG_DEBUG)
+
+test_handler:
+	$(GO) test $(TEST_ARGS) $(PKG_HANDLER)
 
 test_str:
 	$(GO) test $(TEST_ARGS) $(PKG_STR)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ bench:
 bench_goid:
 	$(GO) test -bench='BenchmarkGoid' $(PKG_ASSERT)
 
+bench_reca:
+	$(GO) test -bench='BenchmarkRecursion.*' $(PKG_ERR2)
+
 bench_out:
 	$(GO) test -bench='BenchmarkTryOut_.*' $(PKG_ERR2)
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ We also mark functions deprecated before they become obsolete. Usually, one
 released version before. We have tested this with a large code base in our
 systems, and it works wonderfully.
 
-More information can be found in the scripts' [readme file](./scripts/README.md).
+More information can be found in the `scripts/` directory [readme
+file](./scripts/README.md).
 
 ## Assertion
 
@@ -435,23 +436,29 @@ Please see the full version history from [CHANGELOG](./CHANGELOG.md).
     simplest `defer` function in the `err`-returning function** . (Please see
     the `defer` benchmarks in the `err2_test.go` and run `make bench_reca`)
   - the solution caused a change to API, where the core reason is Go's
-    optimization "bug". (We don't have confirmation yet)
+    optimization "bug". (We don't have confirmation yet.)
 - Changed API for deferred error handling: `defer err2.Handle/Catch()`
-  - Deprecated:
+  - *Obsolete*:
     ```go
-    defer err2.Handle(&err, func() { // <- relaying closure to access err val
+    defer err2.Handle(&err, func() {}) // <- relaying closure to access err val
     ```
   - Current version:
     ```go
-    defer err2.Handle(&err, func(error) error { // <- err val goes thru
+    defer err2.Handle(&err, func(err error) error { return err }) // not a closure
     ```
-  - Added a new API:
+    Because handler function is not relaying closures any more, it opens a new
+    opportunity to use and build general helper functions: `err2.Noop`, etc.
+  - Use auto-migration scripts especially for large code-bases. More information
+    can be found in the `scripts/` directory's [readme file](./scripts/README.md).
+  - Added a new (*experimental*) API:
     ```go
     defer err2.Handle(&err, func(noerr bool) {
             assert.That(noerr) // noerr is always true!!
             doSomething()
     })
     ```
+    This is experimental because we aren't sure if this is something we want to
+    have in the `err2` package.
 - Bug fixes: `ResultX.Logf()` now works as it should
 - More documentation
 

--- a/README.md
+++ b/README.md
@@ -429,18 +429,28 @@ Please see the full version history from [CHANGELOG](./CHANGELOG.md).
 
 ### Latest Release
 
-##### 0.9.29
-- New API for immediate error handling: `try out handle/catch err`
-  ```go
-  val := try.Out1(strconv.Atoi(s)).Catch(10)
-  ```
-- New err2.Catch API for automatic logging
-- Performance boost for assert pkg: `defer assert.PushTester(t)()`
-- Our API has now *all the same features Zig's error handling has*
+##### 0.9.40
+- Huge performance boost for: `defer err2.Handle/Catch()` 
+  - **3x faster happy path**, tested 100 deep call stack with every lvl has `defer`
+  - solution caused change to API (core reason is Go's optimization "bug")
+- Changed API for deferred error handling: `defer err2.Handle/Catch()`
+  - deprecated:
+    ```go
+    defer err2.Handle(&err, func() { // THE OLD, deprecated API
+    defer err2.Handle(&err, func(error) error { // The New CURRENT API
+    ```
+  - added:
+    ```go
+    defer err2.Handle(&err, func(noerr bool) {
+            assert.That(noerr) // noerr is always true!!
+            doSomething()
+    })
+    ```
+- More documentation
 
 ### Upcoming releases
 
-##### 0.9.3 
+##### 0.9.5
 - Go's standard lib's flag pkg integration (similar to `glog`)
 - Continue removing unused parts from `assert` pkg
 - More documentation, repairing for some sort of marketing

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ func CopyFile(src, dst string) (err error) {
 		return fmt.Errorf("mixing traditional error checking: %w", err)
 	}
 	defer err2.Handle(&err, err2.Err(func(error) {
-		os.Remove(dst)
+		try.Out1(os.Remove(dst)).Logf("cleaning error")
 	}))
 	defer w.Close()
 	try.To1(io.Copy(w, r))
@@ -430,30 +430,34 @@ Please see the full version history from [CHANGELOG](./CHANGELOG.md).
 ### Latest Release
 
 ##### 0.9.40
-- Huge performance boost for: `defer err2.Handle/Catch()` 
+- Significant performance boost for: `defer err2.Handle/Catch()` 
   - **3x faster happy path than the previous version, which is now equal to
-    simplest `defer` function in the err-returning function** . (Please see the
-    `defer` benchmarks in the `err2_test.go` and run `make bench_reca`)
+    simplest `defer` function in the `err`-returning function** . (Please see
+    the `defer` benchmarks in the `err2_test.go` and run `make bench_reca`)
   - the solution caused a change to API, where the core reason is Go's
     optimization "bug". (We don't have confirmation yet)
 - Changed API for deferred error handling: `defer err2.Handle/Catch()`
-  - deprecated:
+  - Deprecated:
     ```go
-    defer err2.Handle(&err, func() { // THE OLD, deprecated API
-    defer err2.Handle(&err, func(error) error { // The New CURRENT API
+    defer err2.Handle(&err, func() { // <- relaying closure to access err val
     ```
-  - added:
+  - Current version:
+    ```go
+    defer err2.Handle(&err, func(error) error { // <- err val goes thru
+    ```
+  - Added a new API:
     ```go
     defer err2.Handle(&err, func(noerr bool) {
             assert.That(noerr) // noerr is always true!!
             doSomething()
     })
     ```
+- Bug fixes: `ResultX.Logf()` now works as it should
 - More documentation
 
 ### Upcoming releases
 
 ##### 0.9.5
-- Go's standard lib's flag pkg integration (similar to `glog`)
+- Idea: Go's standard lib's flag pkg integration (similar to `glog`)
 - Continue removing unused parts from `assert` pkg
 - More documentation, repairing for some sort of marketing

--- a/README.md
+++ b/README.md
@@ -431,8 +431,11 @@ Please see the full version history from [CHANGELOG](./CHANGELOG.md).
 
 ##### 0.9.40
 - Huge performance boost for: `defer err2.Handle/Catch()` 
-  - **3x faster happy path**, tested 100 deep call stack with every lvl has `defer`
-  - solution caused change to API (core reason is Go's optimization "bug")
+  - **3x faster happy path than the previous version, which is now equal to
+    simplest `defer` function in the err-returning function** . (Please see the
+    `defer` benchmarks in the `err2_test.go` and run `make bench_reca`)
+  - the solution caused a change to API, where the core reason is Go's
+    optimization "bug". (We don't have confirmation yet)
 - Changed API for deferred error handling: `defer err2.Handle/Catch()`
   - deprecated:
     ```go

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ func CopyFile(src, dst string) (err error) {
 	if err != nil {
 		return fmt.Errorf("mixing traditional error checking: %w", err)
 	}
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, err2.Err(func(error) {
 		os.Remove(dst)
-	})
+	}))
 	defer w.Close()
 	try.To1(io.Copy(w, r))
 	return nil

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -28,24 +28,28 @@ const (
 	// name, line number, and caller function.
 	Development
 
-	// Test minimalistic asserter for unit test use. Much more pragmatic is the
-	// TestFull assert that is the default if test asserter isn't given and
-	// still PushTester is called.
-	// Deprecated: Use TestFull instead.
+	// Test minimalistic asserter for unit test use. More pragmatic is the
+	// TestFull asserter (default).
+	//
+	// Use this asserter if your IDE/editor doesn't support long file names, or
+	// for temporary problem solving for your programming environment.
 	Test
 
-	// TestFull assert that is the default if no test asserter is given and
-	// still PushTester is called. The TestFull asserter includes caller info
-	// and call stack to tests similarly like err2's error traces. You need a
-	// proper test result parser like 'github.com/lainio/nvim-go' (fork). Also
-	// most of the make-go-parsers can process the output properly and allow
-	// traverse of locations of the error trace.
-
-	// The call stack produced by these err2/assert test asserts can be used
-	// over package boundaries. For example, if your app and it's sub packages
-	// use err2/asserts for both tests and runtime asserts the results will be
-	// automatically merged. If any of the runtime asserts fails in app tests
-	// from the sub packages the current test fails too.
+	// TestFull asserter (default). The TestFull asserter includes caller info
+	// and call stack for unit testing, similarly like err2's error traces.
+	//
+	// The call stack produced by the test asserts can be used over Go module
+	// boundaries. For example, if your app and it's sub packages both use
+	// err2/assert for unit testing and runtime checks, the runtime assertions
+	// will be automatically converted to test asserts on the fly. If any of
+	// the runtime asserts in sub packages fails during the app tests, the
+	// current app test fails too.
+	//
+	// Note, that the cross-module assertions produce long file names (path
+	// included), and some of the Go test result parsers cannot handle that.
+	// A proper test result parser like 'github.com/lainio/nvim-go' (fork)
+	// works very well. Also most of the make result parsers can process the
+	// output properly and allow traverse of locations of the error trace.
 	TestFull
 
 	// Debug asserter transforms assertion violations to panics which is the
@@ -131,6 +135,11 @@ const (
 //
 // Because PushTester returns PopTester it allows us to merge these two calls to
 // one line. See the first t.Run call. NOTE. More information in PopTester.
+//
+// PushTester allows you to change the current default asserter by accepting it
+// as a second argument. NOTE. That it change the default asserter for whole
+// package. The argument is mainly for temporary development use and isn't not
+// preferrred API usage.
 func PushTester(t testing.TB, a ...defInd) function {
 	if len(a) > 0 {
 		SetDefault(a[0])

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -99,8 +99,7 @@ func PushTester(t testing.TB, a ...defInd) function {
 	} else if Default()&AsserterUnitTesting == 0 {
 		// if this is forgotten or tests don't have proper place to set it
 		// it's good to keep the API as simple as possible
-		SetDefault(Test)
-		// TODO: parallel testing is something we should test.
+		SetDefault(TestFull)
 	}
 	testers.Tx(func(m testersMap) {
 		rid := goid()

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -16,10 +16,48 @@ import (
 type defInd = uint32
 
 const (
+	// Production is the best asserter for most uses. The assertion violations
+	// are treated as Go error values. And only a pragmatic caller info is
+	// automatically included into the error message like file name, line
+	// number, and caller function.
 	Production defInd = 0 + iota
+
+	// Development is the best asserter for most development uses. The
+	// assertion violations are treated as Go error values. And a formatted
+	// caller info is automatically included to the error message like file
+	// name, line number, and caller function.
 	Development
+
+	// Test minimalistic asserter for unit test use. Much more pragmatic is the
+	// TestFull assert that is the default if test asserter isn't given and
+	// still PushTester is called.
+	// Deprecated: Use TestFull instead.
 	Test
+
+	// TestFull assert that is the default if no test asserter is given and
+	// still PushTester is called. The TestFull asserter includes caller info
+	// and call stack to tests similarly like err2's error traces. You need a
+	// proper test result parser like 'github.com/lainio/nvim-go' (fork). Also
+	// most of the make-go-parsers can process the output properly and allow
+	// traverse of locations of the error trace.
+
+	// The call stack produced by these err2/assert test asserts can be used
+	// over package boundaries. For example, if your app and it's sub packages
+	// use err2/asserts for both tests and runtime asserts the results will be
+	// automatically merged. If any of the runtime asserts fails in app tests
+	// from the sub packages the current test fails too.
 	TestFull
+
+	// Debug asserter transforms assertion violations to panics which is the
+	// patter that e.g. Go's standard library uses:
+	//
+	//   if p == nil {
+	//        panic("pkg: ptr cannot be nil")
+	//   }
+	//
+	// is equal to:
+	//
+	//   assert.NotNil(p)
 	Debug
 )
 

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -18,7 +18,7 @@ func ExampleThat() {
 	}
 	err := sample()
 	fmt.Printf("%v", err)
-	// Output: testing run example: assertion test
+	// Output: testing: run example: assertion test
 }
 
 func ExampleNotNil() {

--- a/doc.go
+++ b/doc.go
@@ -34,9 +34,9 @@ them. The CopyFile example shows how it works:
 	     w := try.To1(os.Create(dst))
 	     // Add error handler to clean up the destination file. Place it here that
 	     // the next deferred close is called before our Remove call.
-	     defer err2.Handle(&err, func() {
+	     defer err2.Handle(&err, err2.Err(func(error) {
 	     	os.Remove(dst)
-	     })
+	     }))
 	     defer w.Close()
 
 	     // Try to copy the file. If error occurs now, all previous error handlers

--- a/err2.go
+++ b/err2.go
@@ -80,10 +80,9 @@ func Handle(err *error, a ...any) {
 	// We put real panic objects back and keep only those which are
 	// carrying our errors. We must also call all of the handlers in defer
 	// stack.
-	handler.PreProcess(&handler.Info{
+	*err = handler.PreProcess(err, &handler.Info{
 		CallerName: "Handle",
 		Any:        r,
-		Err:        err,
 	}, a...)
 }
 
@@ -130,11 +129,10 @@ func Catch(a ...any) {
 	}
 
 	var err error
-	handler.PreProcess(&handler.Info{
+	err = handler.PreProcess(&err, &handler.Info{
 		CallerName: "Catch",
 		Any:        r,
 		NilHandler: handler.NilNoop,
-		Err:        &err,
 	}, a...)
 	doTrace(err)
 }

--- a/err2.go
+++ b/err2.go
@@ -72,7 +72,7 @@ func Handle(err *error, a ...any) {
 	// how how it works with defer.
 	r := recover()
 
-	if !handler.WorkToDo(r, err) {
+	if !handler.WorkToDo(r, err) && !handler.NoerrCallToDo(a...) {
 		return
 	}
 

--- a/err2_test.go
+++ b/err2_test.go
@@ -182,7 +182,7 @@ func TestPanicking_Handle(t *testing.T) {
 			},
 			annErr,
 		},
-		{"general error thru panic",
+		{"general error thru panic: handle nil: no automatic",
 			args{
 				func() (err error) {
 					// If we want keep same error value second argument
@@ -393,7 +393,7 @@ func ExampleHandle_errThrow() {
 	}
 	err := transport()
 	fmt.Printf("%v", err)
-	// Output: testing run example: our error
+	// Output: testing: run example: our error
 }
 
 func ExampleHandle_errReturn() {

--- a/err2_test.go
+++ b/err2_test.go
@@ -49,6 +49,26 @@ func TestTry_Error(t *testing.T) {
 	t.Fail() // If everything works we are never here
 }
 
+func TestHandle_NoError(t *testing.T) {
+	var err error
+	var handlerCalled bool
+	defer func() {
+		test.RequireEqual(t, handlerCalled, true)
+	}()
+	defer err2.Handle(&err, func(err error) error {
+		// this should not be called, so lets try to fuckup things...
+		handlerCalled = false
+		return err
+	})
+
+	// This is the handler we are thesting!
+	defer err2.Handle(&err, func(noerr bool) {
+		handlerCalled = noerr
+	})
+
+	try.To(noErr())
+}
+
 func TestPanickingCatchAll(t *testing.T) {
 	type args struct {
 		f func()

--- a/err2_test.go
+++ b/err2_test.go
@@ -638,6 +638,28 @@ func BenchmarkRecursionWithTryCall(b *testing.B) {
 	}
 }
 
+func BenchmarkRecursionWithTryAnd_Empty_Defer(b *testing.B) {
+	var recursion func(a int) (r int, err error)
+	recursion = func(a int) (r int, err error) {
+		defer func(e error) { // try to be as close to our case, but simple!
+			err = e
+		}(err)
+
+		if a == 0 {
+			return 0, nil
+		}
+		s := try.To1(noThrow())
+		_ = s
+		r = try.To1(recursion(a - 1))
+		r += a
+		return r, nil
+	}
+
+	for n := 0; n < b.N; n++ {
+		_, _ = recursion(100)
+	}
+}
+
 func BenchmarkRecursionWithTryAndDefer(b *testing.B) {
 	var recursion func(a int) (r int, err error)
 	recursion = func(a int) (r int, err error) {

--- a/err2_test.go
+++ b/err2_test.go
@@ -398,6 +398,21 @@ func TestSetErrorTracer(t *testing.T) {
 	test.Require(t, w == nil, "error tracer should be nil")
 }
 
+func ExampleCatch_withFmt() {
+	// Set default logger to stdout for this example
+	oldLogW := err2.LogTracer()
+	err2.SetLogTracer(os.Stdout)
+	defer err2.SetLogTracer(oldLogW)
+
+	transport := func() {
+		// See how Catch follows given format string similarly as Handle
+		defer err2.Catch("catch")
+		err2.Throwf("our error")
+	}
+	transport()
+	// Output: catch: our error
+}
+
 func ExampleHandle() {
 	var err error
 	defer err2.Handle(&err)

--- a/err2_test.go
+++ b/err2_test.go
@@ -53,7 +53,7 @@ func TestHandle_NoError(t *testing.T) {
 	var err error
 	var handlerCalled bool
 	defer func() {
-		test.RequireEqual(t, handlerCalled, true)
+		test.Require(t, handlerCalled)
 	}()
 	defer err2.Handle(&err, func(err error) error {
 		// this should not be called, so lets try to fuckup things...

--- a/err2_test.go
+++ b/err2_test.go
@@ -62,7 +62,7 @@ func TestPanickingCatchAll(t *testing.T) {
 			args{
 				func() {
 					defer err2.Catch(
-						func(err error) error { return err },
+						err2.Noop,
 						func(v any) {},
 					)
 					panic("panic")
@@ -74,7 +74,7 @@ func TestPanickingCatchAll(t *testing.T) {
 			args{
 				func() {
 					defer err2.Catch(
-						func(err error) error { return err },
+						err2.Err(func(error) {}), // Using simplifier
 						func(v any) {},
 					)
 					var b []byte
@@ -96,7 +96,7 @@ func TestPanickingCatchAll(t *testing.T) {
 		{"stop panic with error handler in catch",
 			args{
 				func() {
-					defer err2.Catch(func(err error) error { return err })
+					defer err2.Catch(err2.Noop)
 					var b []byte
 					b[0] = 0
 				},
@@ -127,7 +127,7 @@ func TestPanickingCarryOn_Handle(t *testing.T) {
 			args{
 				func() {
 					var err error
-					defer err2.Handle(&err, func(err error) error { return err })
+					defer err2.Handle(&err, err2.Noop)
 					panic("panic")
 				},
 			},
@@ -137,7 +137,7 @@ func TestPanickingCarryOn_Handle(t *testing.T) {
 			args{
 				func() {
 					var err error
-					defer err2.Handle(&err, func(err error) error { return err })
+					defer err2.Handle(&err, err2.Noop)
 					var b []byte
 					b[0] = 0
 				},
@@ -207,7 +207,7 @@ func TestPanicking_Handle(t *testing.T) {
 		{"general panic plus err handler",
 			args{
 				func() (err error) {
-					defer err2.Handle(&err, func(err error) error { return err })
+					defer err2.Handle(&err, err2.Noop)
 					panic("panic")
 				},
 			},
@@ -294,7 +294,7 @@ func TestPanicking_Catch(t *testing.T) {
 		{"general panic",
 			args{
 				func() {
-					defer err2.Catch(func(err error) error { return err })
+					defer err2.Catch(err2.Noop)
 					panic("panic")
 				},
 			},
@@ -303,7 +303,7 @@ func TestPanicking_Catch(t *testing.T) {
 		{"runtime.error panic",
 			args{
 				func() {
-					defer err2.Catch(func(err error) error { return err })
+					defer err2.Catch(err2.Noop)
 					var b []byte
 					b[0] = 0
 				},

--- a/filecopy_test.go
+++ b/filecopy_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package err2_test
 
 import (

--- a/filecopy_test.go
+++ b/filecopy_test.go
@@ -40,5 +40,5 @@ func Example() {
 	// in real word example 'run example' is 'copy file' it comes automatically
 	// from function name that calls `err2.Handle` in deferred.
 
-	// Output: testing run example: open /notfound/path/file.go: no such file or directory
+	// Output: testing: run example: open /notfound/path/file.go: no such file or directory
 }

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -1,0 +1,86 @@
+package color
+
+import "runtime"
+
+const (
+	reset  = "\033[0m"
+	red    = "\033[31m"
+	green  = "\033[32m"
+	yellow = "\033[33m"
+	blue   = "\033[34m"
+	purple = "\033[35m"
+	cyan   = "\033[36m"
+	gray   = "\033[37m"
+	white  = "\033[97m"
+)
+
+var (
+	isWindows bool
+)
+
+func init() {
+	isWindows = runtime.GOOS == "windows"
+}
+
+func Reset() string {
+	if isWindows {
+		return ""
+	}
+	return reset
+}
+
+func Red() string {
+	if isWindows {
+		return ""
+	}
+	return red
+}
+
+func Green() string {
+	if isWindows {
+		return ""
+	}
+	return green
+}
+
+func Yellow() string {
+	if isWindows {
+		return ""
+	}
+	return yellow
+}
+
+func Blue() string {
+	if isWindows {
+		return ""
+	}
+	return blue
+}
+
+func Purple() string {
+	if isWindows {
+		return ""
+	}
+	return purple
+}
+
+func Cyan() string {
+	if isWindows {
+		return ""
+	}
+	return cyan
+}
+
+func Gray() string {
+	if isWindows {
+		return ""
+	}
+	return gray
+}
+
+func White() string {
+	if isWindows {
+		return ""
+	}
+	return white
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -138,6 +138,7 @@ func (i *Info) workError() (err error) {
 
 func (i *Info) fmtErr() {
 	*i.Err = fmt.Errorf(i.Format+i.wrapStr(), append(i.Args, i.werr)...)
+	i.werr = *i.Err // remember change both our errors!
 }
 
 func (i *Info) buildFmtErr() {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -226,6 +226,8 @@ func Process(info *Info) {
 	}
 }
 
+// PreProcess is currently used for err2 API like err2.Handle and .Catch.
+//   - replaces the Process
 func PreProcess(errPtr *error, info *Info, a ...any) error {
 	// Bug in Go?
 	// start to use local error ptr only for optimization reasons.

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -314,13 +314,10 @@ func processArg(info *Info, i int, a ...any) {
 		info.NilHandler = first
 	case PanicHandler: // err2.Catch uses this
 		info.PanicHandler = first
-		//	case NilHandler:
-		//		info.NilHandler = first
 	case CheckHandler:
 		info.CheckHandler = first
 	case nil:
-		info.NilHandler = NilNoop // TODO: this resets the error!! need
-		// argument!!!
+		info.NilHandler = NilNoop
 	default:
 		// we don't panic here because we can already be in recovery, but lets
 		// try to show an error message at least.

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/lainio/err2/internal/color"
 	"github.com/lainio/err2/internal/debug"
 	fmtstore "github.com/lainio/err2/internal/formatter"
 	"github.com/lainio/err2/internal/str"
@@ -340,8 +341,13 @@ func processArg(info *Info, i int, a ...any) {
 		info.NilHandler = NilNoop
 	default:
 		// we don't panic here because we can already be in recovery, but lets
-		// try to show an error message at least.
-		fmt.Fprintln(os.Stderr, "fatal error: err2.Handle: unsupported type")
+		// try to show an RED error message at least.
+		const msg = `err2 fatal error:  
+---
+unsupported handler function type: err2.Handle/Catch:
+see 'err2/scripts/README.md' and run auto-migration scripts for your repo
+---`
+		fmt.Fprintln(os.Stderr, color.Red()+msg+color.Reset())
 	}
 }
 

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -147,9 +147,9 @@ func TestPreProcess_debug(t *testing.T) {
 	// and that's what error stack tracing is all about
 	Handle()
 
-	test.RequireEqual(t, panicHandlerCalled, false)
-	test.RequireEqual(t, errorHandlerCalled, false)
-	test.RequireEqual(t, nilHandlerCalled, false)
+	test.Require(t, !panicHandlerCalled)
+	test.Require(t, !errorHandlerCalled)
+	test.Require(t, !nilHandlerCalled)
 
 	// See the name of this test function. Decamel it + error
 	const want = "testing: t runner: error"

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -27,9 +27,6 @@ func TestProcess(t *testing.T) {
 		args args
 		want want
 	}{
-		// TODO: this test e.g. has problem because Process is not called
-		// anymore if Any and Err are nil. Check is done before Process call.
-		// - check with handler.WorkToDo() should we even test this.
 		{"all nil and our handlers",
 			args{Info: handler.Info{
 				Any:          nil,
@@ -285,10 +282,9 @@ func panicHandler(_ any) {
 	panicHandlerCalled = true
 }
 
-func nilHandlerForAnnotate() error {
+func nilHandlerForAnnotate(err error) error {
 	nilHandlerCalled = true
-	// in real case this is closure and it has access to err val
-	myErrVal = fmt.Errorf("nil annotate: %v", "error")
+	myErrVal = fmt.Errorf("nil annotate: %w", err)
 	return myErrVal
 }
 
@@ -303,7 +299,7 @@ func errorHandler(err error) error {
 	return err
 }
 
-func nilHandler() error {
+func nilHandler(err error) error {
 	nilHandlerCalled = true
-	return nil
+	return err
 }

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -26,6 +26,9 @@ func TestProcess(t *testing.T) {
 		args args
 		want want
 	}{
+		// TODO: this test e.g. has problem because Process is not called
+		// anymore if Any and Err are nil. Check is done before Process call.
+		// - check with handler.WorkToDo() should we even test this.
 		{"all nil and our handlers",
 			args{Info: handler.Info{
 				Any:          nil,

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -137,7 +137,7 @@ var Info = handler.Info{
 
 func Handle() {
 	a := []any{}
-	Info.Err = &myErrVal // TODO: middle of the perf-refactoring
+	Info.Err = &myErrVal
 	myErrVal = handler.PreProcess(&myErrVal, &Info, a...)
 }
 
@@ -152,7 +152,7 @@ func TestPreProcess_debug(t *testing.T) {
 	test.RequireEqual(t, nilHandlerCalled, false)
 
 	// See the name of this test function. Decamel it + error
-	const want = "testing t runner: error"
+	const want = "testing: t runner: error"
 	test.RequireEqual(t, myErrVal.Error(), want)
 
 	resetCalled()
@@ -233,7 +233,6 @@ func TestPreProcess(t *testing.T) {
 				var err = x.Whom(tt.args.Info.Err != nil,
 					*tt.args.Info.Err, nil)
 
-				// TODO: we should assign it to myErrVal
 				err = handler.PreProcess(&err, &tt.args.Info, tt.args.a...)
 
 				test.RequireEqual(t, panicHandlerCalled, tt.want.panicCalled)

--- a/internal/str/str.go
+++ b/internal/str/str.go
@@ -45,6 +45,8 @@ func Decamel(s string) string {
 		if toSpace {
 			if prevSkipped {
 				continue
+			} else if v == '.' {
+				b.WriteRune(':')
 			}
 			v = ' '
 			prevSkipped = true

--- a/internal/str/str.go
+++ b/internal/str/str.go
@@ -32,6 +32,8 @@ func Decamel(s string) string {
 		isUpper     bool
 		prevSkipped bool
 	)
+	b.Grow(2 * len(s))
+
 	for i, v := range s {
 		skip := v == '(' || v == ')' || v == '*'
 		if skip {

--- a/internal/str/str_test.go
+++ b/internal/str/str_test.go
@@ -40,11 +40,11 @@ func TestDecamel(t *testing.T) {
 		{"acronym", args{"ARMCamelString"}, "armcamel string"},
 		{"acronym at end", args{"archIsARM"}, "arch is arm"},
 		{"simple method", args{"(*DIDAgent).AssertWallet"}, "didagent assert wallet"},
-		{"package name and simple method", args{"ssi.(*DIDAgent).AssertWallet"}, "ssi didagent assert wallet"},
-		{"simple method and anonym", args{"(*DIDAgent).AssertWallet.Func1"}, "didagent assert wallet func1"},
-		{"complex method and anonym", args{"(**DIDAgent).AssertWallet.Func1"}, "didagent assert wallet func1"},
-		{"unnatural method and anonym", args{"(**DIDAgent)...AssertWallet...Func1"}, "didagent assert wallet func1"},
-		{"from spf13 cobra", args{"bot.glob..func5"}, "bot glob func5"},
+		{"package name and simple method", args{"ssi.(*DIDAgent).AssertWallet"}, "ssi: didagent assert wallet"},
+		{"simple method and anonym", args{"(*DIDAgent).AssertWallet.Func1"}, "didagent assert wallet: func1"},
+		{"complex method and anonym", args{"(**DIDAgent).AssertWallet.Func1"}, "didagent assert wallet: func1"},
+		{"unnatural method and anonym", args{"(**DIDAgent)...AssertWallet...Func1"}, "didagent assert wallet: func1"},
+		{"from spf13 cobra", args{"bot.glob..func5"}, "bot: glob: func5"},
 	}
 	for _, tt := range tests {
 		s := tt.args.s

--- a/internal/x/x.go
+++ b/internal/x/x.go
@@ -41,5 +41,3 @@ func Swap[T any](lhs, rhs *T) (nlhs T) {
 	*rhs = swap
 	return *lhs
 }
-
-// TODO: , Max, ...

--- a/samples/README.md
+++ b/samples/README.md
@@ -4,14 +4,20 @@ Please play with the samples by editing them and running the main files:
 - `main.go` just a starter for different playgrounds
 - `main-play.go` general playground based on CopyFile and recursion
 - `main-db-sample.go` simulates DB transaction and money transfer
+- `main-nil.go` samples and tests for logger and using `err2.Handle` for success
 
 Run a default playground `play` mode:
 ```go
-go run main.go
+go run ./...
 ```
 
 Or run the DB based version to maybe better understand how powerful the
 automatic error string building is:
 ```go
-go run main.go -mode db
+go run ./... -mode db
+```
+
+You can print usage:
+```go
+go run ./... -h
 ```

--- a/samples/main-db-sample.go
+++ b/samples/main-db-sample.go
@@ -9,6 +9,8 @@ import (
 	"github.com/lainio/err2/try"
 )
 
+// TODO: test migrations with these samples!
+
 func (db *Database) MoneyTransfer(from, to *Account, amount int) (err error) {
 	defer err2.Handle(&err)
 

--- a/samples/main-db-sample.go
+++ b/samples/main-db-sample.go
@@ -9,23 +9,23 @@ import (
 	"github.com/lainio/err2/try"
 )
 
-// TODO: test migrations with these samples!
-
 func (db *Database) MoneyTransfer(from, to *Account, amount int) (err error) {
 	defer err2.Handle(&err)
 
 	tx := try.To1(db.BeginTransaction())
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		if errRoll := tx.Rollback(); errRoll != nil {
 			// with go 1.20: err = fmt.Errorf("%w: ROLLBACK ERROR: %w", err, errRoll)
 			err = fmt.Errorf("%v: ROLLBACK ERROR: %w", err, errRoll)
 		}
+		return err
 	})
 
 	try.To(from.ReserveBalance(tx, amount))
 
-	defer err2.Handle(&err, func() { // optional, following sample's wording
+	defer err2.Handle(&err, func(err error) error { // optional, following sample's wording
 		err = fmt.Errorf("cannot %w", err)
+		return err
 	})
 
 	try.To(from.Withdraw(tx, amount))

--- a/samples/main-nil.go
+++ b/samples/main-nil.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"errors"
+	"os"
+
+	"github.com/lainio/err2"
+	"github.com/lainio/err2/try"
+	"golang.org/x/exp/slog"
+)
+
+var (
+	opts = slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}
+
+	errAddNode = errors.New("add node error")
+	myErr error = nil
+
+	logger *slog.Logger
+)
+
+func Init() {
+	textHandler := opts.NewTextHandler(os.Stdout)
+	logger = slog.New(textHandler)
+	slog.SetDefault(logger)
+	if *isErr {
+		myErr = errAddNode
+	}
+}
+
+func doMainAll()  {
+	logger.Info("=== 1. preferred successful status output ===")
+	doMain1()
+	logger.Info("=== 2. NilThen and try.To successful status ===")
+	doMain2()
+	logger.Info("=== 3. NilThen and try.Out successful status ===")
+	doMain3()
+
+	logger.Info("=== ERROR status versions ===")
+	myErr = errAddNode
+	logger.Info("=== 1. preferred successful status output ===")
+	doMain1()
+	logger.Info("=== 2. NilThen and try.To successful status ===")
+	doMain2()
+	logger.Info("=== 3. NilThen and try.Out successful status ===")
+	doMain3()
+}
+func doMain3() {
+	defer err2.Catch("CATCH")
+	logger.Debug("3: ADD node")
+	defer NilThen(func() {
+		logger.Debug("3: add node successful")
+	})
+	try.Out(AddNode()).Logf("3: no error handling, only logging")
+}
+
+func doMain2() {
+	defer err2.Catch("CATCH")
+	logger.Debug("2: ADD node")
+	defer NilThen(func() {
+		logger.Debug("2: add node successful")
+	})
+
+	try.To(AddNode())
+}
+
+func doMain1() {
+	defer err2.Catch("CATCH")
+	logger.Debug("1: ADD node")
+
+	try.To(AddNode())
+	logger.Debug("1: add node successful")
+}
+
+func AddNode() error { return myErr }
+
+func NilThen(fn func()) {
+	if r := recover(); r != nil {
+		panic(r)
+	}
+	fn()
+}
+

--- a/samples/main-nil.go
+++ b/samples/main-nil.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/lainio/err2"
+	"github.com/lainio/err2/assert"
 	"github.com/lainio/err2/try"
 	"golang.org/x/exp/slog"
 )
@@ -34,18 +35,18 @@ func doMainAll() {
 
 	logger.Info("=== 1. preferred successful status output ===")
 	doMain1()
-	logger.Info("=== 2. NilThen and try.To successful status ===")
+	logger.Info("=== 2. err2.Handle(NilThenerr, func(noerr)) and try.To successful status ===")
 	doMain2()
-	logger.Info("=== 3. NilThen and try.Out successful status ===")
+	logger.Info("=== 3. err2.Handle(NilThenerr, func(noerr)) and try.Out successful status ===")
 	doMain3()
 
 	logger.Info("=== ERROR status versions ===")
 	myErr = errAddNode
 	logger.Info("=== 1. preferred successful status output ===")
 	doMain1()
-	logger.Info("=== 2. NilThen and try.To successful status ===")
+	logger.Info("=== 2. err2.Handle(NilThenerr, func(noerr)) and try.To successful status ===")
 	doMain2()
-	logger.Info("=== 3. NilThen and try.Out successful status ===")
+	logger.Info("=== 3. err2.Handle(NilThenerr, func(noerr)) and try.Out successful status ===")
 	doMain3()
 }
 
@@ -54,7 +55,9 @@ func doMain3() {
 
 	defer err2.Catch("CATCH")
 	logger.Debug("3: ADD node")
-	defer NilThen(func() {
+	var err error
+	defer err2.Handle(&err, func(noerr bool) {
+		assert.That(noerr)
 		logger.Debug("3: add node successful")
 	})
 	try.Out(AddNode()).Logf("3: no error handling, only logging")
@@ -65,7 +68,9 @@ func doMain2() {
 
 	defer err2.Catch("CATCH")
 	logger.Debug("2: ADD node")
-	defer NilThen(func() {
+	var err error
+	defer err2.Handle(&err, func(noerr bool) {
+		assert.That(noerr)
 		logger.Debug("2: add node successful")
 	})
 
@@ -83,10 +88,3 @@ func doMain1() {
 }
 
 func AddNode() error { return myErr }
-
-func NilThen(fn func()) {
-	if r := recover(); r != nil {
-		panic(r)
-	}
-	fn()
-}

--- a/samples/main-nil.go
+++ b/samples/main-nil.go
@@ -15,7 +15,7 @@ var (
 	}
 
 	errAddNode = errors.New("add node error")
-	myErr error = nil
+	myErr      error
 
 	logger *slog.Logger
 )
@@ -29,7 +29,7 @@ func Init() {
 	}
 }
 
-func doMainAll()  {
+func doMainAll() {
 	logger.Info("=== 1. preferred successful status output ===")
 	doMain1()
 	logger.Info("=== 2. NilThen and try.To successful status ===")
@@ -81,4 +81,3 @@ func NilThen(fn func()) {
 	}
 	fn()
 }
-

--- a/samples/main-nil.go
+++ b/samples/main-nil.go
@@ -30,6 +30,8 @@ func Init() {
 }
 
 func doMainAll() {
+	Init()
+
 	logger.Info("=== 1. preferred successful status output ===")
 	doMain1()
 	logger.Info("=== 2. NilThen and try.To successful status ===")
@@ -46,7 +48,10 @@ func doMainAll() {
 	logger.Info("=== 3. NilThen and try.Out successful status ===")
 	doMain3()
 }
+
 func doMain3() {
+	Init()
+
 	defer err2.Catch("CATCH")
 	logger.Debug("3: ADD node")
 	defer NilThen(func() {
@@ -56,6 +61,8 @@ func doMain3() {
 }
 
 func doMain2() {
+	Init()
+
 	defer err2.Catch("CATCH")
 	logger.Debug("2: ADD node")
 	defer NilThen(func() {
@@ -66,6 +73,8 @@ func doMain2() {
 }
 
 func doMain1() {
+	Init()
+
 	defer err2.Catch("CATCH")
 	logger.Debug("1: ADD node")
 

--- a/samples/main-play.go
+++ b/samples/main-play.go
@@ -56,7 +56,7 @@ func OrgCopyFile(src, dst string) (err error) {
 		return fmt.Errorf("mixing traditional error checking: %w", err)
 	}
 	defer err2.Handle(&err, func() {
-		os.Remove(dst)
+		try.Out(os.Remove(dst)).Logf("cleaning error")
 	})
 	defer w.Close()
 	try.To1(io.Copy(w, r))

--- a/samples/main-play.go
+++ b/samples/main-play.go
@@ -27,8 +27,9 @@ func CopyFile(src, dst string) (err error) {
 	defer r.Close()
 
 	w := try.To1(os.Create(dst))
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		try.Out(os.Remove(dst)).Logf()
+		return err
 	})
 	defer w.Close()
 
@@ -55,8 +56,9 @@ func OrgCopyFile(src, dst string) (err error) {
 	if err != nil {
 		return fmt.Errorf("mixing traditional error checking: %w", err)
 	}
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		try.Out(os.Remove(dst)).Logf("cleaning error")
+		return err
 	})
 	defer w.Close()
 	try.To1(io.Copy(w, r))

--- a/samples/main-play.go
+++ b/samples/main-play.go
@@ -21,6 +21,24 @@ import (
 // CopyFile copies the source file to the given destination. If any error occurs it
 // returns an error value describing the reason.
 func CopyFile(src, dst string) (err error) {
+	defer err2.Handle(&err)
+
+	r := try.To1(os.Open(src))
+	defer r.Close()
+
+	w := try.To1(os.Create(dst))
+	defer err2.Handle(&err, func() {
+		try.Out(os.Remove(dst)).Logf()
+	})
+	defer w.Close()
+
+	try.To1(io.Copy(w, r))
+	return nil
+}
+
+// OrgCopyFile copies the source file to the given destination. If any error occurs it
+// returns an error value describing the reason.
+func OrgCopyFile(src, dst string) (err error) {
 	defer err2.Handle(&err) // automatic error message: see err2.Formatter
 	// You can out-comment above handler line(s) to see what happens.
 
@@ -112,7 +130,7 @@ func doMain() (err error) {
 	// how err2 works. Especially interesting is automatic stack tracing.
 	//
 	// source file exists, but the destination is not in high probability
-	//try.To(CopyFile("main.go", "/notfound/path/file.bak"))
+	try.To(CopyFile("main.go", "/notfound/path/file.bak"))
 
 	// Both source and destination don't exist
 	//try.To(CopyFile("/notfound/path/file.go", "/notfound/path/file.bak"))

--- a/samples/main.go
+++ b/samples/main.go
@@ -17,7 +17,6 @@ func main() {
 	log.SetFlags(log.Lshortfile | log.LstdFlags)
 
 	flag.Parse()
-	Init()
 
 	switch *mode {
 	case "db":

--- a/samples/main.go
+++ b/samples/main.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	mode = flag.String("mode", "play", "runs the wanted playground: db, play,")
+	mode = flag.String("mode", "play", "runs the wanted playground: db, play, nil")
+	isErr = flag.Bool("err", false, "tells if we have error")
 )
 
 func main() {
@@ -16,10 +17,17 @@ func main() {
 	log.SetFlags(log.Lshortfile | log.LstdFlags)
 
 	flag.Parse()
+	Init()
 
 	switch *mode {
 	case "db":
 		doDBMain()
+	case "nil":
+		doMainAll()
+	case "nil1":
+		doMain1()
+	case "nil2":
+		doMain2()
 	case "play":
 		doPlayMain()
 	default:

--- a/samples/main.go
+++ b/samples/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	mode = flag.String("mode", "play", "runs the wanted playground: db, play, nil")
+	mode  = flag.String("mode", "play", "runs the wanted playground: db, play, nil")
 	isErr = flag.Bool("err", false, "tells if we have error")
 )
 

--- a/samples/main.go
+++ b/samples/main.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	mode  = flag.String("mode", "play", "runs the wanted playground: db, play, nil")
-	isErr = flag.Bool("err", false, "tells if we have error")
+	isErr = flag.Bool("err", false, "tells if we want to have an error")
 )
 
 func main() {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,37 +9,60 @@ successfully from type variables (see below) to Go generics API.
 This readme will guide you to use auto-migration scripts when ever we deprecate
 functions or make something obsolete.
 
-### `err2.Catch(func() {})` -> `err2.Catch(func(error) error {})` and others in v0.9.40
+### Auto-Migration of v0.9.40
 
-The version 0.9.40 is a major update because of the performance. We have managed
-to eliminate `defer` slowdown. Our benchmarks are 3x faster than previous
-version and about equal to those function call stacks (100 level) that don't use
-`defer`. We are exactly at the same level of performance with those functions
-that use deferred function that accept an argument. Transporting an argument to
-deferred function seems to be slower than functions that don't. And because
-`try.To` is already as fast as `if err != nil` we reached our goal for speed!
+The version 0.9.40 is a major update because of the performance and API change.
+We have managed to eliminate `defer` slowdown. Our benchmarks are 3x faster than
+previous version and about equal to those function call stacks (100 level) that
+don't use `defer`. We are exactly at the same level of performance with those
+functions that use deferred function that accept an argument. Transporting an
+argument to deferred function seems to be slower than functions that don't. And
+because `try.To` is already as fast as `if err != nil` we reached our goal for
+speed!
 
 Because all of the error handler function signatures are now:
 ```go
 	ErrorHandler = func(err error) error
 ```
 and the old one was `func()` relaying closures. And because we have dynamic
-signatures on `err2.Handle` and `err2.Catch`, we cannot use compiler for type
-checking, which makes this so important but difficult. The `err2` package writes
-problems to `stderr` because it cannot panic in middle of the panicking. Note.
-This is only a legacy code problem. We are migration as you see :-)
+signatures on `err2.Handle` and `err2.Catch`, we cannot use compiler (Go lacks
+the function overloading) for type checking, which makes this migration so
+important but difficult. The `err2` package writes `fatal error: ...` to
+`stderr` because it cannot panic in middle of the panicking.
 
-#### Manual v0.9.40 Migration With Location List (nvim/vim)
+> Note. This is only a legacy code problem. We are in the migration as you can
+> see :-)
+
+You have two (2) options for migration for v0.9.40:
+1. [(Semi)-Automatic Migration](#semi-automatic-migration)
+1. [Manual migration using (vim/nvim) location lists or similar](manual-migration-with-a-location-list)
+
+#### (Semi)-Automatic Migration
+
+Follow these steps:
+1. [Set up Migration Environment](#set-up-migration-environment)
+1. Make sure that you haven't uncommitted changes in your repo and that you are
+   in the branch where you want to make the changes.
+1. Execute following command in your repo's root directory:
+   ```shell
+   migr-name.sh -n repl_handle_func repl_catch_func
+   ```
+1. Then continue with `build`, `test`, `lint`, etc. **And don't stop yet.**
+1. Use `git diff` or similar to skimming that all changes seem to be OK. Here
+   you have an opportunity to start use new features of `err2` like logging.
+1. You are ready to commit changes.
+
+#### Manual Migration With a Location List
 
 Follow these steps check do you have migration needs for v0.9.40:
 1. [Set up Migration Environment](#set-up-migration-environment)
 1. Execute following command in your repo's root directory:
    ```shell
-   migr-name.sh -ndv todo_handle_func todo_catch_func
+   migr-name.sh -n todo_handle_func todo_catch_func
    ```
 
 *Tip. If your repo is large and you have many migration changes see the next
-[semi-automatic guide](#semi-automatic-v0.9.40-migration).*
+[semi-automatic guide](#semi-automatic-migration).*
 
 *Tip. You can execute that command from e.g. nvim/vim and you get your fix list.*
 ```shell
@@ -50,21 +73,6 @@ nvim -q todo_list
 ```shell
 nvim -q <(migr-name.sh todo_handle_func todo_catch_func)
 ```
-
-#### Semi-Automatic v0.9.40 Migration
-
-Follow these steps:
-1. [Set up Migration Environment](#set-up-migration-environment)
-1. Make sure that you haven't uncommitted changes in your repo and that you are
-   in the branch where you want to make the changes.
-1. Execute following command in your repo's root directory:
-   ```shell
-   migr-name.sh -ndv repl_handle_func repl_catch_func
-   ```
-1. Then continue with `build`, `test`, `lint`, etc. **And don't stop yet.**
-1. Use `git diff` or similar to skimming that all changes seem to be OK. Here
-   you have an opportunity to start use new features of `err2` like logging.
-1. You are ready to commit changes.
 
 ### `assert.SetDefaultAsserter` -> `assert.SetDefault` and others in v0.9.1
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,8 +20,33 @@ Because all of the error handler function signatures are now:
 ```go
 	ErrorHandler = func(err error) error
 ```
-and the old one was `func()` and we dynamic signatures on `err2.Handle` and
-`err2.Catch` we cannot use compiler for type checking.
+and the old one was `func()` relaying closures. And because we have dynamic
+signatures on `err2.Handle` and `err2.Catch`, we cannot use compiler for type
+checking, which makes this so important but difficult. The `err2` package writes
+problems to `stderr` because it cannot panic in middle of the panicking. Note.
+This is only a legacy code problem. We are migration as you see :-)
+
+Follow these steps check do you have migration needs for v0.9.40:
+1. [Set up Migration Environment](#set-up-migration-environment)
+1. Execute following command:
+   ```shell
+   migr-name.sh todo_handle_func todo_catch_func
+   ```
+
+*Tip. You can execute that command from e.g. nvim/vim and you get your fix list.*
+```shell
+migr-name.sh todo_handle_func todo_catch_func > todo_list
+nvim -q todo_list
+```
+*Or depending on your current shell:*
+```shell
+nvim -q <(migr-name.sh todo_handle_func todo_catch_func)
+```
+
+**Note. We are still in middle to process check if we can make this migration
+automatic, at least semi-automatic. Probably we cannot do the same as with
+others because the error value setting isn't closure anymore where we can refer
+the `err` return variable directly.**
 
 ### `assert.SetDefaultAsserter` -> `assert.SetDefault` and others in v0.9.1
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 The err2 package will offer auto-migration scripts until version 1.0.0 is
 published. That means that you can safely use the package even the API is not
-yet 100% staple. We have used that approach for our production code that uses
+yet 100% stable. We have used that approach for our production code that uses
 `err2` and it works very well. Over 100 KLOC Go code has been auto-migrated
 successfully from type variables (see below) to Go generics API.
 
@@ -13,12 +13,12 @@ functions or make something obsolete.
 
 The version 0.9.40 is a major update because of the performance and API change.
 We have managed to eliminate `defer` slowdown. Our benchmarks are 3x faster than
-previous version and about equal to those function call stacks (100 level) that
-don't use `defer`. We are exactly at the same level of performance with those
-functions that use deferred function that accept an argument. Transporting an
-argument to deferred function seems to be slower than functions that don't. And
-because `try.To` is already as fast as `if err != nil` we reached our goal for
-speed!
+previous version and about equal to those function call stacks (100 deep-level)
+that don't use `defer`. We are exactly at the same level of performance with
+those functions that use deferred function that accept an argument. Transporting
+an argument to deferred function seems to be slower than functions that don't.
+And because `try.To` is already as fast as `if err != nil` we reached our goal
+for speed!
 
 Because all of the error handler function signatures are now:
 ```go
@@ -35,7 +35,8 @@ important but difficult. The `err2` package writes `fatal error: ...` to
 
 You have two (2) options for migration for v0.9.40:
 1. [(Semi)-Automatic Migration](#semi-automatic-migration)
-1. [Manual migration using (vim/nvim) location lists or similar](manual-migration-with-a-location-list)
+1. [Manual migration using (vim/nvim) location lists or
+   similar](#manual-migration-with-a-location-list)
 
 #### (Semi)-Automatic Migration
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,10 +11,13 @@ functions or make something obsolete.
 
 ### `err2.Catch(func() {})` -> `err2.Catch(func(error) error {})` and others in v0.9.40
 
-The version 0.9.40 has major update because of the performance. We have managed
-to eliminate `defer` slowdown. Our benchmarks are 3x faster and about equal to
-those function call stacks (100 level) that don't use `defer`. And because
-`try.To` is already as fast as `if err != nil` we reached our goal in speedwise!
+The version 0.9.40 is a major update because of the performance. We have managed
+to eliminate `defer` slowdown. Our benchmarks are 3x faster than previous
+version and about equal to those function call stacks (100 level) that don't use
+`defer`. We are exactly at the same level of performance with those functions
+that use deferred function that accept an argument. Transporting an argument to
+deferred function seems to be slower than functions that don't. And because
+`try.To` is already as fast as `if err != nil` we reached our goal for speed!
 
 Because all of the error handler function signatures are now:
 ```go

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,12 +29,17 @@ checking, which makes this so important but difficult. The `err2` package writes
 problems to `stderr` because it cannot panic in middle of the panicking. Note.
 This is only a legacy code problem. We are migration as you see :-)
 
+#### Manual v0.9.40 Migration With Location List (nvim/vim)
+
 Follow these steps check do you have migration needs for v0.9.40:
 1. [Set up Migration Environment](#set-up-migration-environment)
-1. Execute following command:
+1. Execute following command in your repo's root directory:
    ```shell
-   migr-name.sh todo_handle_func todo_catch_func
+   migr-name.sh -ndv todo_handle_func todo_catch_func
    ```
+
+*Tip. If your repo is large and you have many migration changes see the next
+[semi-automatic guide](#semi-automatic-v0.9.40-migration).*
 
 *Tip. You can execute that command from e.g. nvim/vim and you get your fix list.*
 ```shell
@@ -46,10 +51,20 @@ nvim -q todo_list
 nvim -q <(migr-name.sh todo_handle_func todo_catch_func)
 ```
 
-**Note. We are still in middle to process check if we can make this migration
-automatic, at least semi-automatic. Probably we cannot do the same as with
-others because the error value setting isn't closure anymore where we can refer
-the `err` return variable directly.**
+#### Semi-Automatic v0.9.40 Migration
+
+Follow these steps:
+1. [Set up Migration Environment](#set-up-migration-environment)
+1. Make sure that you haven't uncommitted changes in your repo and that you are
+   in the branch where you want to make the changes.
+1. Execute following command in your repo's root directory:
+   ```shell
+   migr-name.sh -ndv repl_handle_func repl_catch_func
+   ```
+1. Then continue with `build`, `test`, `lint`, etc. **And don't stop yet.**
+1. Use `git diff` or similar to skimming that all changes seem to be OK. Here
+   you have an opportunity to start use new features of `err2` like logging.
+1. You are ready to commit changes.
 
 ### `assert.SetDefaultAsserter` -> `assert.SetDefault` and others in v0.9.1
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,20 @@ successfully from type variables (see below) to Go generics API.
 This readme will guide you to use auto-migration scripts when ever we deprecate
 functions or make something obsolete.
 
+### `err2.Catch(func() {})` -> `err2.Catch(func(error) error {})` and others in v0.9.40
+
+The version 0.9.40 has major update because of the performance. We have managed
+to eliminate `defer` slowdown. Our benchmarks are 3x faster and about equal to
+those function call stacks (100 level) that don't use `defer`. And because
+`try.To` is already as fast as `if err != nil` we reached our goal in speedwise!
+
+Because all of the error handler function signatures are now:
+```go
+	ErrorHandler = func(err error) error
+```
+and the old one was `func()` and we dynamic signatures on `err2.Handle` and
+`err2.Catch` we cannot use compiler for type checking.
+
 ### `assert.SetDefaultAsserter` -> `assert.SetDefault` and others in v0.9.1
 
 Because direct renaming causes braking changes remember add -x flag to your

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -467,7 +467,7 @@ todo_handle_func() {
 
 todo_catch_func() {
 	dlog "searching old error handlers"
-	ag 'err2\.Catch\(func\(err error\)'
+	ag 'err2\.Catch\(func\(err error\) \{'
 }
 
 lint() {

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -60,9 +60,9 @@ check_prerequisites() {
 	fi
 
 	local go_version=$(go mod edit -json | jq -r '."Go"')
-	if [[ $go_version < 1.19 ]]; then
+	if [[ $go_version < 1.18 ]]; then
 		echo "ERROR:  Go version number ($go_version) is too low" >&2
-		echo "Sample: go mod edit -go=1.19 # sets the minimal version" >&2
+		echo "Sample: go mod edit -go=1.18 # sets the minimal version" >&2
 		exit 1
 	fi
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -353,8 +353,8 @@ clean() {
 
 search_0_multi='(^\s*)(err)( :?= )((.|\n)*?)(\n)(\s*try\.To\(err\))' 
 search_1_multi='(^\s*[\w\.]*)(, err)( :?= )([\s\S]*?)(\n)(\s*try\.To\(err\))'
-search_2_multi="(^\s*[\w\.]*, [\w\.]*)(, err)( :?= )([\s\S]*?)(\n)(\s*try\.To\(err\))"
-search_3_multi="(^\s*[\w\.]*, [\w\.]*, [\w\.]*)(, err)( :?= )([\s\S]*?)(\n)(\s*try\.To\(err\))"
+search_2_multi='(^\s*[\w\.]*, [\w\.]*)(, err)( :?= )([\s\S]*?)(\n)(\s*try\.To\(err\))'
+search_3_multi='(^\s*[\w\.]*, [\w\.]*, [\w\.]*)(, err)( :?= )([\s\S]*?)(\n)(\s*try\.To\(err\))'
 
 # other tested versions, left here for debugging purposes
 #search_2_multi="(^\s*\w*, \w*)(, err)( :?= )([\s\S]*?)(\n)(\s*try\.To\(err\))"
@@ -460,14 +460,28 @@ todo_assert() {
 	ag 'assert\.[DP]+\.'
 }
 
+search_handle_multi='(^\s*)(defer err2\.Handle\(&err, func\(\) \{)([\s\S]*?)(^\s*\}\)$)'
+
 todo_handle_func() {
-	dlog "searching old error handlers"
-	ag 'err2\.Handle\(&err, func\(\)'
+	vlog "searching old error Handlers"
+	ag "$search_handle_multi"
 }
 
+repl_handle_func() {
+	vlog "replacing old error Handlers"
+	check_commit "$search_handle_multi" '\1defer err2.Handle(&err, func(err error) error {\3\1\treturn err\n\1})'
+}
+
+search_catch_multi='(^\s*)(defer err2\.Catch\(func\(err error\) \{)([\s\S]*?)(^\s*\}\)$)'
+
 todo_catch_func() {
-	dlog "searching old error handlers"
-	ag 'err2\.Catch\(func\(err error\) \{'
+	vlog "searching old error Catchers"
+	ag "$search_catch_multi"
+}
+
+repl_catch_func() {
+	vlog "replacing old error Catchers"
+	check_commit "$search_catch_multi" '\1defer err2.Catch(err2.Err(func(err error) {\3\1}))'
 }
 
 lint() {

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -460,6 +460,16 @@ todo_assert() {
 	ag 'assert\.[DP]+\.'
 }
 
+todo_handle_func() {
+	dlog "searching old error handlers"
+	ag 'err2\.Handle\(&err, func\(\)'
+}
+
+todo_catch_func() {
+	dlog "searching old error handlers"
+	ag 'err2\.Catch\(func\(err error\)'
+}
+
 lint() {
 	dlog "Linter check for missing defers"
 	ag '^\s*err2\.(Handle|Catch)'

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+GO_MIN_VER=1.18
+
 filtered_build() {
 	local osname=$(uname -s)
 	local pkg=${1:-"./..."}
@@ -60,9 +62,9 @@ check_prerequisites() {
 	fi
 
 	local go_version=$(go mod edit -json | jq -r '."Go"')
-	if [[ $go_version < 1.18 ]]; then
+	if [[ $go_version < $GO_MIN_VER ]]; then
 		echo "ERROR:  Go version number ($go_version) is too low" >&2
-		echo "Sample: go mod edit -go=1.18 # sets the minimal version" >&2
+		echo "Sample: go mod edit -go=$GO_MIN_VER # sets the minimal version" >&2
 		exit 1
 	fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,10 +2,22 @@
 
 set -e
 
-if [[ -z "$1" ]]; then
-	echo "ERROR: give version number, e.g. v0.8.2"
-	exit 1
-fi
+check_prerequisites() {
+	for c in git go goreleaser; do
+		if ! [[ -x "$(command -v ${c})" ]]; then
+			echo "ERR: missing command: '${c}'." >&2
+			echo "Please install before continue." >&2
+			exit 1
+		fi
+	done
+
+	if [[ -z "$1" ]]; then
+		echo "ERROR: give version number, e.g. v0.8.2"
+		exit 1
+	fi
+}
+
+check_prerequisites $1
 
 version="$1"
 cur_branch=$(git rev-parse --abbrev-ref HEAD)
@@ -20,6 +32,7 @@ if [[ -z "$(git status --porcelain)" ]]; then
 	git tag -a "$version" -m "v. $version"
 	git push origin "$cur_branch" --tags
 	GOPROXY=proxy.golang.org go list -m github.com/lainio/err2@"$version"
+	goreleaser release
 else
 	echo 'ERROR: working dir is not clean'
 fi

--- a/snippets/go.json
+++ b/snippets/go.json
@@ -7,8 +7,8 @@
 		},
 		"defer err2.Catch func": {
 			"prefix": "ecaf",
-			"body": "defer err2.Catch(func(err error) {\n\t$0\n})\n",
-			"description": "Snippet for err2.Catch(func(err error) {})"
+			"body": "defer err2.Catch(func(err error) error {\n\t$0\n})\n",
+			"description": "Snippet for err2.Catch(func(err error) error {})"
 		},
 		"defer err2.Handle": {
 			"prefix": "eha",
@@ -22,8 +22,8 @@
 		},
 		"defer err2.Handle func": {
 			"prefix": "ehaf",
-			"body": "defer err2.Handle(&err, func() {\n\t$0\n})\n",
-			"description": "Snippet for err2.Handle(&err, func() {})"
+			"body": "defer err2.Handle(&err, func(err error) error {\n\t$0\n})\n",
+			"description": "Snippet for err2.Handle(&err, func(err error) error {})"
 		},
 		"defer assert.PushTester(t)()": {
 			"prefix": "aspa",

--- a/try/notfound_test.go
+++ b/try/notfound_test.go
@@ -28,9 +28,9 @@ func ExampleIsNotFound1() {
 	err2.SetErrorTracer(nil)
 
 	find := func(key int) string {
-		defer err2.Catch(func(err error) {
+		defer err2.Catch(err2.Err(func(err error) {
 			fmt.Println("ERROR:", err)
-		})
+		}))
 		notFound, value := try.IsNotFound1(FindObject(key))
 		if notFound {
 			return fmt.Sprintf("cannot find key (%d)", key)

--- a/try/out.go
+++ b/try/out.go
@@ -40,14 +40,17 @@ type (
 //
 //	error sending response: UDP not listening
 func (o *Result) Logf(a ...any) *Result {
-	if o.Err == nil || len(a) == 0 {
+	if o.Err == nil {
 		return o
 	}
-	f, isFormat := a[0].(string)
-	if isFormat {
-		s := fmt.Sprintf(f+": %v", append(a[1:], o.Err)...)
-		_ = handler.LogOutput(2, s)
+	s := o.Err.Error()
+	if len(a) != 0 {
+		f, isFormat := a[0].(string)
+		if isFormat {
+			s = fmt.Sprintf(f+": %v", append(a[1:], o.Err)...)
+		}
 	}
+	_ = handler.LogOutput(2, s)
 	return o
 }
 

--- a/try/out.go
+++ b/try/out.go
@@ -11,19 +11,22 @@ type (
 	// ErrFn is function type for try.OutX handlers.
 	ErrFn = func(err error) error
 
-	// Result is the base of our error handling DSL for try.Out functions.
+	// Result is the base of our error handling language for try.Out functions.
 	Result struct {
+		// Err holds the error value returned from try.Out function result.
 		Err error
 	}
 
 	// Result1 is the base of our error handling DSL for try.Out1 functions.
 	Result1[T any] struct {
+		// Val1 holds the first value returned from try.Out1 function result.
 		Val1 T
 		Result
 	}
 
 	// Result2 is the base of our error handling DSL for try.Out2 functions.
 	Result2[T any, U any] struct {
+		// Val2 holds the first value returned from try.Out2 function result.
 		Val2 U
 		Result1[T]
 	}

--- a/try/out.go
+++ b/try/out.go
@@ -43,18 +43,7 @@ type (
 //
 //	error sending response: UDP not listening
 func (o *Result) Logf(a ...any) *Result {
-	if o.Err == nil {
-		return o
-	}
-	s := o.Err.Error()
-	if len(a) != 0 {
-		f, isFormat := a[0].(string)
-		if isFormat {
-			s = fmt.Sprintf(f+": %v", append(a[1:], o.Err)...)
-		}
-	}
-	_ = handler.LogOutput(2, s)
-	return o
+	return o.logf(logfFrameLvl, a...)
 }
 
 // Logf prints a log line to pre-set logging stream (err2.SetLogWriter)
@@ -68,7 +57,7 @@ func (o *Result) Logf(a ...any) *Result {
 //
 //	error sending response: UDP not listening
 func (o *Result1[T]) Logf(a ...any) *Result1[T] {
-	o.Result.Logf(a...)
+	o.Result.logf(logfFrameLvl, a...)
 	return o
 }
 
@@ -83,7 +72,7 @@ func (o *Result1[T]) Logf(a ...any) *Result1[T] {
 //
 //	error sending response: UDP not listening
 func (o *Result2[T, U]) Logf(a ...any) *Result2[T, U] {
-	o.Result.Logf(a...)
+	o.Result.logf(logfFrameLvl, a...)
 	return o
 }
 
@@ -272,3 +261,22 @@ func Out2[T any, U any](v1 T, v2 U, err error) *Result2[T, U] {
 func wrapStr() string {
 	return ": %w"
 }
+
+func (o *Result) logf(lvl int, a ...any) *Result {
+	if o.Err == nil {
+		return o
+	}
+	s := o.Err.Error()
+	if len(a) != 0 {
+		f, isFormat := a[0].(string)
+		if isFormat {
+			s = fmt.Sprintf(f+": %v", append(a[1:], o.Err)...)
+		}
+	}
+	_ = handler.LogOutput(lvl, s)
+	return o
+}
+
+const (
+	logfFrameLvl = 4
+)

--- a/try/out.go
+++ b/try/out.go
@@ -112,7 +112,6 @@ func (o *Result) Handle(a ...any) *Result {
 		o.Err = fmt.Errorf(f+wrapStr(), append(a[1:], o.Err)...)
 	case ErrFn:
 		o.Err = f(o.Err)
-		panic(o.Err)
 	case error:
 		if len(a) == 2 {
 			hfn, haveHandlerFn := a[1].(ErrFn)

--- a/try/out_test.go
+++ b/try/out_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package try_test
 
 import (

--- a/try/out_test.go
+++ b/try/out_test.go
@@ -93,7 +93,9 @@ func TestResult2_Logf(t *testing.T) {
 	err2.SetLogTracer(os.Stdout)
 
 	convTwoStr := func(s1, s2 string) (_ int, _ int, err error) {
-		defer err2.Handle(&err, nil)
+		//defer err2.Handle(&err, nil) // TODO: why this is not working!!
+		//TODO
+		defer err2.Handle(&err)
 
 		return try.To1(strconv.Atoi(s1)), try.To1(strconv.Atoi(s2)), nil
 	}
@@ -103,8 +105,8 @@ func TestResult2_Logf(t *testing.T) {
 	}
 	num1, num2 := countSomething("1", "err")
 	fmt.Printf("results: %d, %d\n", num1, num2)
-	test.RequireEqual(t, num1, 3)
 	test.RequireEqual(t, num2, 2)
+	test.RequireEqual(t, num1, 3)
 }
 
 func TestResult_Handle(t *testing.T) {

--- a/try/out_test.go
+++ b/try/out_test.go
@@ -93,9 +93,7 @@ func TestResult2_Logf(t *testing.T) {
 	err2.SetLogTracer(os.Stdout)
 
 	convTwoStr := func(s1, s2 string) (_ int, _ int, err error) {
-		//defer err2.Handle(&err, nil) // TODO: why this is not working!!
-		//TODO
-		defer err2.Handle(&err)
+		defer err2.Handle(&err, nil)
 
 		return try.To1(strconv.Atoi(s1)), try.To1(strconv.Atoi(s2)), nil
 	}

--- a/try/out_test.go
+++ b/try/out_test.go
@@ -107,6 +107,26 @@ func TestResult2_Logf(t *testing.T) {
 	test.RequireEqual(t, num2, 2)
 }
 
+func TestResult_Handle(t *testing.T) {
+	// try out f() |err| handle to show how to stop propagate error
+	callFn := func(mode int) (err error) {
+		defer err2.Handle(&err)
+
+		try.Out(fmt.Errorf("test error")).Handle(func(err error) error {
+			if mode == 0 {
+				return err
+			}
+			return nil // no error to throw
+		})
+		return nil
+	}
+	err := callFn(1)
+	test.Requiref(t, err == nil, "no error when Out.Handle sets it nil")
+
+	err = callFn(0)
+	test.Requiref(t, err != nil, "want error when Out.Handle sets it the same")
+}
+
 func ExampleResult1_Handle() {
 	// try out f() |err| handle to show power of error handling language, EHL
 	callRead := func(in io.Reader, b []byte) (eof bool, n int) {

--- a/try/result2_test.go
+++ b/try/result2_test.go
@@ -29,6 +29,6 @@ func ExampleResult2_Logf() {
 	num1, num2 := countSomething("WRONG", "2")
 	fmt.Printf("results: %d, %d", num1, num2)
 	err2.SetLogTracer(nil)
-	// Output: testing run example: strconv.Atoi: parsing "WRONG": invalid syntax
+	// Output: testing: run example: strconv.Atoi: parsing "WRONG": invalid syntax
 	// results: 20, 10
 }

--- a/try/result2_test.go
+++ b/try/result2_test.go
@@ -21,7 +21,7 @@ func ExampleResult2_Logf() {
 	err2.SetLogTracer(os.Stdout)
 
 	countSomething := func(s1, s2 string) (int, int) {
-		r := try.Out2(convTwoStr(s1, s2)).Logf("not number").Def2(10, 10)
+		r := try.Out2(convTwoStr(s1, s2)).Logf().Def2(10, 10)
 		v1, v2 := r.Val1, r.Val2
 		return v1 + v2, v2
 	}
@@ -29,6 +29,6 @@ func ExampleResult2_Logf() {
 	num1, num2 := countSomething("WRONG", "2")
 	fmt.Printf("results: %d, %d", num1, num2)
 	err2.SetLogTracer(nil)
-	// Output: not number: testing run example: strconv.Atoi: parsing "WRONG": invalid syntax
+	// Output: testing run example: strconv.Atoi: parsing "WRONG": invalid syntax
 	// results: 20, 10
 }

--- a/try/try.go
+++ b/try/try.go
@@ -11,7 +11,7 @@ about err2 and try packager roles can be seen in the FileCopy example:
 	w := try.To1(os.Create(dst))
 	defer err2.Handle(&err, func(error) error {
 	     try.To(os.Remove(dst)).Logf()
-		return nil
+	     return nil
 	})
 	defer w.Close()
 	try.To1(io.Copy(w, r))

--- a/try/try.go
+++ b/try/try.go
@@ -9,8 +9,9 @@ about err2 and try packager roles can be seen in the FileCopy example:
 	defer r.Close()
 
 	w := try.To1(os.Create(dst))
-	defer err2.Handle(&err, func() {
-	     os.Remove(dst)
+	defer err2.Handle(&err, func(error) error {
+	     try.To(os.Remove(dst)).Logf()
+		return nil
 	})
 	defer w.Close()
 	try.To1(io.Copy(w, r))

--- a/try/try_test.go
+++ b/try/try_test.go
@@ -111,9 +111,9 @@ func Example_copyFile() {
 		defer r.Close()
 
 		w := try.To1(os.Create(dst))
-		defer err2.Handle(&err, func() {
+		defer err2.Handle(&err, err2.Err(func(error) {
 			os.Remove(dst)
-		})
+		}))
 		defer w.Close()
 		try.To1(io.Copy(w, r))
 		return nil

--- a/try/try_test.go
+++ b/try/try_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package try_test
 
 import (
@@ -51,11 +53,12 @@ func ExampleIs_errorHappensNot() {
 	// Output: wrapping works
 }
 
+//nolint:unparam
 func ExampleOut_errorHappensNot() {
 	var is bool
-	var errFn = func(_ error) (err error) { //nolint:unparam
+	var errFn = func(error) error {
 		is = true
-		return
+		return nil
 	}
 	copyStream := func(src string) (s string, err error) {
 		defer err2.Handle(&err, "copy stream %s", src)


### PR DESCRIPTION
- new test for out.Handle
- documentation for the asserter constants
- go documentation update
- new bench rule
- new samles to test certain features
- 3x faster deferred err handlers!!
- all error handlers: func(err error) error
- snippets for new error handler signature
- new error handler signature docs & handler helpers: Noop,..
- Logf works without argument
- guides started for signature change
- Decamel separates pkg name with colon
- func(error) error: is a new handler signature
- migration readme for Handle/Catch signature change
- new err2.Handle API called when err == nil, experimental!
- reference benchmark to compare how well our err2.Handle is optimized
- performance boost explanation
- add test/example for Catch fmt & bug fix
- automigration quide
- informative RED runtime error message when type error detected
- added documentation to Result structs
- Decamel alloc optimization
- migration README
- finalizing v0.9.40
