### PR TITLE
Fix: Error annotations fail when user functions contain "Handle" in their name

### DIFF
--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -135,6 +135,36 @@ func TestIsFuncAnchor(t *testing.T) {
 		{"package name only", args{
 			"github.com/lainio/err2/try.To1[...](...)",
 			StackInfo{"lainio/err2", "", 0, nil, nil, false}}, true},
+		{"user function containing Handle should not match", args{
+			"main.FirstHandle(0x40000b3ed8, 0x40000b3ef8)",
+			StackInfo{"", "Handle", 0, nil, nil, false}}, false},
+		{"user function containing Handle matches err2.Handle", args{
+			"github.com/lainio/err2.Handle(0x40000b3ed8, 0x40000b3ef8)",
+			StackInfo{"", "Handle", 0, nil, nil, false}}, true},
+		{"user function named exactly Handle should not match", args{
+			"main.Handle(0x40000b3ed8, 0x40000b3ef8)",
+			StackInfo{"", "Handle", 0, nil, nil, false}}, false},
+		{"user package function named Handle should not match", args{
+			"mypackage.Handle(0x40000b3ed8, 0x40000b3ef8)",
+			StackInfo{"", "Handle", 0, nil, nil, false}}, false},
+		{"err2.Handle should match", args{
+			"err2.Handle(0x40000b3ed8, 0x40000b3ef8)",
+			StackInfo{"", "Handle", 0, nil, nil, false}}, true},
+		{"lainio/err2.Handle should match", args{
+			"github.com/lainio/err2.Handle(0x40000b3ed8, 0x40000b3ef8)",
+			StackInfo{"", "Handle", 0, nil, nil, false}}, true},
+		{"user package with err2 in path should not match", args{
+			"github.com/mycompany/err2/mypackage.Handle(0x40000b3ed8, 0x40000b3ef8)",
+			StackInfo{"", "Handle", 0, nil, nil, false}}, false},
+		{"versioned err2/v2.Handle should match", args{
+			"github.com/lainio/err2/v2.Handle(0x40000b3ed8, 0x40000b3ef8)",
+			StackInfo{"", "Handle", 0, nil, nil, false}}, true},
+		{"versioned err2/v10.Handle should match", args{
+			"github.com/lainio/err2/v10.Handle(0x40000b3ed8, 0x40000b3ef8)",
+			StackInfo{"", "Handle", 0, nil, nil, false}}, true},
+		{"non-err2 versioned package should not match", args{
+			"github.com/someone/otherpkg/v2.Handle(0x40000b3ed8, 0x40000b3ef8)",
+			StackInfo{"", "Handle", 0, nil, nil, false}}, false},
 	}
 	for _, ttv := range tests {
 		tt := ttv


### PR DESCRIPTION
### Summary

- Fix error annotation when user functions contain the substring “handle” by making function-anchor detection precise.
- Ensures `err2.Handle` stack anchors are matched only for the `err2` package (including versioned modules), not for user functions like `FirstHandle` or `main.Handle`.
- Closes [issue #30](https://github.com/lainio/err2/issues/30).

### Background

When using `err2.Handle(&err)` inside functions whose names contain “handle”, error annotations showed incorrect function names (e.g., `main: main:`). See [Bug: Error annotations fail when user functions contain "Handle" in their name](https://github.com/lainio/err2/issues/30).

### Changes

- Tightened `isFuncAnchor` logic in `err2/internal/debug/debug.go`:
  - Match only at a dot boundary.
  - Require the package token immediately before the dot to be exactly `err2`, or a version token `vN` preceded by `err2` (supports `.../err2/v2.Handle`).
  - Single O(n) scan with `strings.Index`, no regex construction.
- Added helper `isErr2BeforeDot` to validate the package token.
- No changes to `handler` logic; only stack parsing is updated.

### Why this approach

- Prevents substring collisions (e.g., “FirstHandle(”).
- Correctly identifies `err2.Handle` and versioned `err2/vN.Handle`.
- Avoids risky broad checks (like searching for `/err2/` anywhere before).
- Maintains Go 1.18 compatibility (uses `strings.LastIndex`).

### Tests

Added/extended cases in `err2/internal/debug/debug_test.go` to cover:
- Matches:
  - `err2.Handle(...)`
  - `github.com/lainio/err2.Handle(...)`
  - `github.com/lainio/err2/v2.Handle(...)`
  - `github.com/lainio/err2/v10.Handle(...)`
- Non-matches:
  - `main.Handle(...)`
  - `mypackage.Handle(...)`
  - `main.FirstHandle(...)`
  - `github.com/myco/err2/mypackage.Handle(...)`

### Example

Before:
- `Final error: main: main: my error`

After:
- `Final error: first handle: second handle: my error`

### Compatibility and Performance

- Backwards compatible with existing behavior for `err2` stack parsing.
- O(n) per line; no new allocations beyond substring indexing.

### Risks

- Low: Narrowed detection to dot boundaries and `err2`-scoped packages; tests cover edge cases.

### Links

- Issue: [#30](https://github.com/lainio/err2/issues/30)